### PR TITLE
Add Support for Anthropic, Groq, and OpenAI Providers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,8 @@ func NewManager() *Manager {
 	v.RegisterAlias("mistral-key", "providers.mistral.api_key")
 	v.RegisterAlias("cohere-key", "providers.cohere.api_key")
 	v.RegisterAlias("anthropic-key", "providers.anthropic.api_key")
+	v.RegisterAlias("openai-key", "providers.openai.api_key")
+	v.RegisterAlias("groq-key", "providers.groq.api_key")
 
 	// Bind provider API keys to intuitive environment variable names
 	_ = v.BindEnv("providers.mistral.api_key", "MISTRAL_API_KEY")

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -1,0 +1,40 @@
+package anthropic
+
+import "slop/internal/llm/common"
+
+// MessagesRequest represents the request payload for Anthropic's Messages API
+type MessagesRequest struct {
+	Model         string           `json:"model"`
+	MaxTokens     int              `json:"max_tokens"`
+	Messages      []common.Message `json:"messages"`
+	System        string           `json:"system,omitempty"`
+	Temperature   *float64         `json:"temperature,omitempty"`
+	TopP          *float64         `json:"top_p,omitempty"`
+	TopK          *int             `json:"top_k,omitempty"`
+	StopSequences []string         `json:"stop_sequences,omitempty"`
+	Stream        *bool            `json:"stream,omitempty"`
+}
+
+// MessagesResponse represents Anthropic's Messages API response
+type MessagesResponse struct {
+	ID           string         `json:"id"`
+	Type         string         `json:"type"`
+	Role         string         `json:"role"`
+	Content      []ContentItem  `json:"content"`
+	Model        string         `json:"model"`
+	StopReason   string         `json:"stop_reason"`
+	StopSequence string         `json:"stop_sequence"`
+	Usage        AnthropicUsage `json:"usage"`
+}
+
+// ContentItem represents a content item in Anthropic's response
+type ContentItem struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// AnthropicUsage represents usage information in Anthropic's format
+type AnthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}

--- a/internal/llm/anthropic/options.go
+++ b/internal/llm/anthropic/options.go
@@ -1,0 +1,97 @@
+package anthropic
+
+import "slop/internal/llm/common"
+
+// GenerateOptions contains Anthropic-specific generation parameters
+type GenerateOptions struct {
+	common.GenerateOptions
+
+	// Anthropic-specific params
+	TopK          *int     // integer for top-k sampling (only used by some Anthropic models)
+	System        string   // system prompt for Anthropic (separate from messages)
+	StopSequences []string // anthropic uses "stop_sequences" instead of "stop"
+}
+
+// GenerateOption configures Anthropic-specific generation parameters
+type GenerateOption func(*GenerateOptions)
+
+// NewGenerateOptions creates new GenerateOptions with functional options applied
+func NewGenerateOptions(opts ...GenerateOption) *GenerateOptions {
+	config := &GenerateOptions{}
+	for _, opt := range opts {
+		opt(config)
+	}
+	return config
+}
+
+// WithTopK sets top-k sampling parameter
+func WithTopK(topK int) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.TopK = &topK
+	}
+}
+
+// WithSystem sets the system prompt for Anthropic
+func WithSystem(system string) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.System = system
+	}
+}
+
+// WithStopSequences sets stop sequences (Anthropic uses different naming)
+func WithStopSequences(sequences []string) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.StopSequences = sequences
+	}
+}
+
+// Common options
+
+// WithTemperature sets response randomness (0.0-1.0 for Anthropic)
+func WithTemperature(temp float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithTemperature(temp)(&c.GenerateOptions)
+	}
+}
+
+// WithTopP sets nucleus sampling threshold (0.0-1.0)
+func WithTopP(topP float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithTopP(topP)(&c.GenerateOptions)
+	}
+}
+
+// WithMaxTokens sets maximum tokens to generate
+func WithMaxTokens(maxTokens int) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithMaxTokens(maxTokens)(&c.GenerateOptions)
+	}
+}
+
+// WithStop sets stop sequences (maps to StopSequences for Anthropic)
+func WithStop(stop []string) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.StopSequences = stop
+		// Also set the common stop field for consistency
+		common.WithStop(stop)(&c.GenerateOptions)
+	}
+}
+
+// WithJSONFormat enables JSON structured output (if supported)
+func WithJSONFormat() GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithJSONFormat()(&c.GenerateOptions)
+	}
+}
+
+// WithResponseFormat sets structured output format (if supported)
+func WithResponseFormat(format *common.ResponseFormat) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithResponseFormat(format)(&c.GenerateOptions)
+	}
+}
+
+// GetGenerateOptions returns the embedded common GenerateOptions for validation
+func (c *GenerateOptions) GetGenerateOptions() *common.GenerateOptions {
+	return &c.GenerateOptions
+}

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -1,4 +1,4 @@
-// Package anthropic provides a client implementation for the AnthropicAPI.
+// Package anthropic provides a client implementation for the Anthropic API.
 //
 // API Reference: https://docs.anthropic.com/en/api/messages
 // Authentication: providers.anthropic.api_key or ANTHROPIC_API_KEY environment variable
@@ -8,3 +8,285 @@
 //   response, err := client.Generate(ctx, messages, anthropic.WithTemperature(0.7))
 //
 // Anthropic models include: claude-3-5-haiku-latest, claude-sonnet-4-0, claude-opus-4-0
+
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"slop/internal/config"
+	"slop/internal/llm/common"
+)
+
+// Provider implements the unified registry
+type Provider struct{}
+
+// ensure Provider implements the common provider interface
+var _ common.Provider = (*Provider)(nil)
+
+// New creates a new Anthropic provider instance
+func New() *Provider {
+	return &Provider{}
+}
+
+// CreateClient creates a new LLM client using the unified adapter pattern
+func (p *Provider) CreateClient(cfg *config.Config, logger *slog.Logger) (common.LLM, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	if cfg.Providers.Anthropic.APIKey == "" {
+		return nil, fmt.Errorf(`Anthropic API key is required.
+
+You can set the API key using the environment variable ANTHROPIC_API_KEY or via slop config set anthropic-key=<your_api_key>
+Get an API key from https://console.anthropic.com/settings/keys`)
+	}
+
+	// create client options
+	var opts []common.ClientOption
+	if cfg.Providers.Anthropic.BaseUrl != "" {
+		opts = append(opts, common.WithBaseURL(cfg.Providers.Anthropic.BaseUrl))
+	}
+	if logger != nil {
+		opts = append(opts, common.WithLogger(logger))
+	}
+	maxRetries := cfg.Parameters.MaxRetries
+	if maxRetries > 5 {
+		maxRetries = 5 // enforce maximum limit
+	}
+	if maxRetries > 0 {
+		opts = append(opts, common.WithMaxRetries(maxRetries))
+	}
+
+	adapterClient := common.NewAdapterClient(p, cfg.Providers.Anthropic.APIKey, "https://api.anthropic.com/v1", opts...)
+	return adapterClient, nil
+}
+
+// BuildOptions creates Anthropic-specific generation options from configuration
+func (p *Provider) BuildOptions(cfg *config.Config) []interface{} {
+	var functionalOpts []GenerateOption
+
+	// handle system prompt from config
+	if cfg.Parameters.SystemPrompt != "" {
+		functionalOpts = append(functionalOpts, WithSystem(cfg.Parameters.SystemPrompt))
+	}
+
+	if cfg.Parameters.Temperature > 0 {
+		functionalOpts = append(functionalOpts, WithTemperature(cfg.Parameters.Temperature))
+	}
+	if cfg.Parameters.MaxTokens > 0 {
+		functionalOpts = append(functionalOpts, WithMaxTokens(cfg.Parameters.MaxTokens))
+	}
+	if cfg.Parameters.TopP > 0 {
+		functionalOpts = append(functionalOpts, WithTopP(cfg.Parameters.TopP))
+	}
+	if len(cfg.Parameters.StopSequences) > 0 {
+		functionalOpts = append(functionalOpts, WithStopSequences(cfg.Parameters.StopSequences))
+	}
+	if cfg.Format.JSON {
+		functionalOpts = append(functionalOpts, WithJSONFormat())
+	}
+
+	return []interface{}{NewGenerateOptions(functionalOpts...)}
+}
+
+// RequiresAPIKey returns true; Anthropic requires an API key
+func (p *Provider) RequiresAPIKey() bool {
+	return true
+}
+
+// returns the name of this provider
+func (p *Provider) ProviderName() string {
+	return "anthropic"
+}
+
+// BuildRequest creates an Anthropic-specific request from messages and options
+func (p *Provider) BuildRequest(messages []common.Message, modelName string, options interface{}, logger *slog.Logger) (interface{}, error) {
+	// convert options to Anthropic-specific options
+	var config *GenerateOptions
+	if options != nil {
+		if anthropicOpts, ok := options.(*GenerateOptions); ok {
+			config = anthropicOpts
+		} else {
+			config = &GenerateOptions{}
+		}
+	} else {
+		config = &GenerateOptions{}
+	}
+
+	// log the API request using common utilities
+	common.LogAPIRequest(logger, "Anthropic", modelName, messages, &config.GenerateOptions)
+
+	// separate system messages from user/assistant messages
+	var systemPrompt string
+	var filteredMessages []common.Message
+
+	for _, msg := range messages {
+		if msg.Role == "system" {
+			if systemPrompt == "" {
+				systemPrompt = msg.Content
+			} else {
+				systemPrompt += "\n\n" + msg.Content
+			}
+		} else {
+			filteredMessages = append(filteredMessages, msg)
+		}
+	}
+
+	// use system prompt from config if no system messages found
+	if systemPrompt == "" && config.System != "" {
+		systemPrompt = config.System
+	}
+
+	// create Anthropic-specific request payload
+	requestBody := &MessagesRequest{
+		Model:     modelName,
+		Messages:  filteredMessages,
+		MaxTokens: 1024,                  // Anthropic requires max_tokens, so we set a default
+		Stream:    common.BoolPtr(false), // Disable streaming for now
+	}
+
+	// set system prompt if provided
+	if systemPrompt != "" {
+		requestBody.System = systemPrompt
+	}
+
+	// map common generation options to Anthropic's API format
+	if config.Temperature != nil {
+		requestBody.Temperature = config.Temperature
+	}
+	if config.MaxTokens != nil {
+		requestBody.MaxTokens = *config.MaxTokens
+	}
+	if config.TopP != nil {
+		requestBody.TopP = config.TopP
+	}
+
+	// map Anthropic-specific options
+	if config.TopK != nil {
+		requestBody.TopK = config.TopK
+	}
+	if len(config.StopSequences) > 0 {
+		requestBody.StopSequences = config.StopSequences
+	}
+
+	return requestBody, nil
+}
+
+// ParseResponse parses an Anthropic API response and extracts content and usage
+func (p *Provider) ParseResponse(body []byte, logger *slog.Logger) (string, *common.Usage, error) {
+	// parse the response using Anthropic's Messages API format
+	var anthropicResp MessagesResponse
+	if err := json.Unmarshal(body, &anthropicResp); err != nil {
+		common.LogJSONUnmarshalError(logger, err, string(body))
+		return "", nil, fmt.Errorf("failed to unmarshal Anthropic response: %w", err)
+	}
+
+	// extract content from the content array
+	if len(anthropicResp.Content) == 0 {
+		return "", nil, fmt.Errorf("no content in Anthropic response")
+	}
+
+	// concatenate all text content items
+	var contentParts []string
+	for _, item := range anthropicResp.Content {
+		if item.Type == "text" {
+			contentParts = append(contentParts, item.Text)
+		}
+	}
+
+	if len(contentParts) == 0 {
+		return "", nil, fmt.Errorf("no text content in Anthropic response")
+	}
+
+	content := strings.Join(contentParts, "")
+
+	// convert Anthropic usage to common format
+	var usage *common.Usage
+	if anthropicResp.Usage.InputTokens > 0 || anthropicResp.Usage.OutputTokens > 0 {
+		usage = &common.Usage{
+			PromptTokens:     anthropicResp.Usage.InputTokens,
+			CompletionTokens: anthropicResp.Usage.OutputTokens,
+			TotalTokens:      anthropicResp.Usage.InputTokens + anthropicResp.Usage.OutputTokens,
+		}
+	}
+
+	// return content and usage information
+	return content, usage, nil
+}
+
+// HandleError creates Anthropic-specific error messages from HTTP error responses
+func (p *Provider) HandleError(statusCode int, body []byte) error {
+
+	// without the body, we can sometimes provide specific, actionable error messages
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf(`Anthropic API authentication failed.
+
+Check your API key and ensure it is set correctly. 
+You can set the API key using the environment variable ANTHROPIC_API_KEY or via slop config set anthropic-key=<your_api_key>
+Get an API key from https://console.anthropic.com/settings/keys`)
+
+	case http.StatusTooManyRequests:
+		return fmt.Errorf(`Anthropic API rate limit exceeded.
+
+Please try again later or check your limits at https://console.anthropic.com/settings/limits`)
+	}
+
+	// attempt to parse Anthropic's error format
+	var errorResp struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(body, &errorResp); err != nil {
+		// FALLBACK if the response was not the expected JSON format
+		return fmt.Errorf("Anthropic API request failed with status %d: %s", statusCode, string(body))
+	}
+
+	// now we can return a specific error message
+	if errorResp.Error.Message != "" {
+		return fmt.Errorf("Anthropic API error: %s", errorResp.Error.Message)
+	}
+
+	// final catch-all if parsing succeeded but the message was empty
+	return fmt.Errorf("an unknown API error occurred (status %d)", statusCode)
+}
+
+// HandleConnectionError handles connection failures - for cloud services, return original error
+func (p *Provider) HandleConnectionError(err error) error {
+	return err
+}
+
+// Anthropic uses /v1/messages endpoint and requires specific headers
+func (p *Provider) CustomizeRequest(req *http.Request) error {
+	if strings.HasSuffix(req.URL.Path, "/chat/completions") {
+		// handle both "/chat/completions" and "/v1/chat/completions"
+		if strings.HasSuffix(req.URL.Path, "/v1/chat/completions") {
+			req.URL.Path = strings.Replace(req.URL.Path, "/v1/chat/completions", "/v1/messages", 1)
+		} else {
+			req.URL.Path = strings.Replace(req.URL.Path, "/chat/completions", "/v1/messages", 1)
+		}
+	}
+
+	// Anthropic requires x-api-key header instead of Authorization Bearer
+	// see: https://docs.anthropic.com/en/api/overview#authentication
+	authHeader := req.Header.Get("Authorization")
+	if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
+		apiKey := strings.TrimPrefix(authHeader, "Bearer ")
+		req.Header.Del("Authorization")
+		req.Header.Set("x-api-key", apiKey)
+	}
+
+	// Anthropic requires specific API version headers
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	return nil
+}

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -1,0 +1,644 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"slop/internal/config"
+	"slop/internal/llm/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_Interface(t *testing.T) {
+	// verify that Provider implements the common.Provider interface
+	var _ common.Provider = (*Provider)(nil)
+}
+
+func TestNew(t *testing.T) {
+	provider := New()
+	assert.NotNil(t, provider)
+	assert.IsType(t, &Provider{}, provider)
+}
+
+func TestProvider_ProviderName(t *testing.T) {
+	provider := New()
+	assert.Equal(t, "anthropic", provider.ProviderName())
+}
+
+func TestProvider_RequiresAPIKey(t *testing.T) {
+	provider := New()
+	assert.True(t, provider.RequiresAPIKey())
+}
+
+func TestProvider_CreateClient(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name        string
+		config      *config.Config
+		expectError bool
+	}{
+		{
+			name:        "nil config",
+			config:      nil,
+			expectError: true,
+		},
+		{
+			name: "missing API key",
+			config: &config.Config{
+				Providers: config.Providers{
+					Anthropic: config.Anthropic{},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "valid config",
+			config: &config.Config{
+				Providers: config.Providers{
+					Anthropic: config.Anthropic{
+						BaseProvider: config.BaseProvider{
+							APIKey: "test-api-key",
+						},
+					},
+				},
+				Parameters: config.Parameters{
+					MaxRetries: 3,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "config with custom base URL",
+			config: &config.Config{
+				Providers: config.Providers{
+					Anthropic: config.Anthropic{
+						BaseProvider: config.BaseProvider{
+							APIKey:  "test-api-key",
+							BaseUrl: "https://custom.anthropic.com",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := provider.CreateClient(tt.config, slog.Default())
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestProvider_BuildOptions(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name     string
+		config   *config.Config
+		expected int // expected number of options
+	}{
+		{
+			name: "minimal config",
+			config: &config.Config{
+				Parameters: config.Parameters{},
+				Format:     config.Format{},
+			},
+			expected: 1, // always returns at least one GenerateOptions object
+		},
+		{
+			name: "full config",
+			config: &config.Config{
+				Parameters: config.Parameters{
+					SystemPrompt:  "You are a helpful assistant.",
+					Temperature:   0.7,
+					MaxTokens:     1000,
+					TopP:          0.9,
+					StopSequences: []string{"end", "stop"},
+				},
+				Format: config.Format{
+					JSON: true,
+				},
+			},
+			expected: 1, // still returns one GenerateOptions object, but with all options set
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := provider.BuildOptions(tt.config)
+			assert.Len(t, options, tt.expected)
+
+			// verify the first option is a GenerateOptions
+			if len(options) > 0 {
+				generateOpts, ok := options[0].(*GenerateOptions)
+				assert.True(t, ok)
+				assert.NotNil(t, generateOpts)
+			}
+		})
+	}
+}
+
+func TestProvider_BuildRequest(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "system", Content: "You are a helpful assistant."},
+		{Role: "user", Content: "Can you not understand that liberty is worth more than just ribbons?"},
+	}
+	modelName := "claude-3-5-sonnet-latest"
+
+	tests := []struct {
+		name     string
+		options  interface{}
+		expected *MessagesRequest
+	}{
+		{
+			name:    "nil options",
+			options: nil,
+			expected: &MessagesRequest{
+				Model:     modelName,
+				Messages:  []common.Message{{Role: "user", Content: "Can you not understand that liberty is worth more than just ribbons?"}},
+				System:    "You are a helpful assistant.",
+				MaxTokens: 1024,
+				Stream:    common.BoolPtr(false),
+			},
+		},
+		{
+			name: "with generate options",
+			options: NewGenerateOptions(
+				WithTemperature(0.7),
+				WithMaxTokens(1500),
+				WithTopK(10),
+				WithStopSequences([]string{"end", "stop"}),
+			),
+			expected: &MessagesRequest{
+				Model:         modelName,
+				Messages:      []common.Message{{Role: "user", Content: "Can you not understand that liberty is worth more than just ribbons?"}},
+				System:        "You are a helpful assistant.",
+				Temperature:   common.Float64Ptr(0.7),
+				MaxTokens:     1500,
+				TopK:          common.IntPtr(10),
+				StopSequences: []string{"end", "stop"},
+				Stream:        common.BoolPtr(false),
+			},
+		},
+		{
+			name:    "invalid options type",
+			options: "invalid",
+			expected: &MessagesRequest{
+				Model:     modelName,
+				Messages:  []common.Message{{Role: "user", Content: "Can you not understand that liberty is worth more than just ribbons?"}},
+				System:    "You are a helpful assistant.",
+				MaxTokens: 1024,
+				Stream:    common.BoolPtr(false),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := provider.BuildRequest(messages, modelName, tt.options, slog.Default())
+
+			assert.NoError(t, err)
+			assert.NotNil(t, request)
+
+			msgReq, ok := request.(*MessagesRequest)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.expected.Model, msgReq.Model)
+			assert.Equal(t, tt.expected.Messages, msgReq.Messages)
+			assert.Equal(t, tt.expected.System, msgReq.System)
+			assert.Equal(t, tt.expected.Stream, msgReq.Stream)
+
+			if tt.expected.Temperature != nil {
+				require.NotNil(t, msgReq.Temperature)
+				assert.Equal(t, *tt.expected.Temperature, *msgReq.Temperature)
+			}
+			if tt.expected.MaxTokens != 0 {
+				assert.Equal(t, tt.expected.MaxTokens, msgReq.MaxTokens)
+			}
+			if tt.expected.TopK != nil {
+				require.NotNil(t, msgReq.TopK)
+				assert.Equal(t, *tt.expected.TopK, *msgReq.TopK)
+			}
+			if len(tt.expected.StopSequences) > 0 {
+				assert.Equal(t, tt.expected.StopSequences, msgReq.StopSequences)
+			}
+		})
+	}
+}
+
+func TestProvider_BuildRequest_SystemMessageHandling(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name           string
+		messages       []common.Message
+		expectedSystem string
+		expectedMsgLen int
+	}{
+		{
+			name: "single system message",
+			messages: []common.Message{
+				{Role: "system", Content: "You are helpful."},
+				{Role: "user", Content: "Hello"},
+			},
+			expectedSystem: "You are helpful.",
+			expectedMsgLen: 1,
+		},
+		{
+			name: "multiple system messages",
+			messages: []common.Message{
+				{Role: "system", Content: "You are helpful."},
+				{Role: "user", Content: "Hello"},
+				{Role: "system", Content: "Be concise."},
+			},
+			expectedSystem: "You are helpful.\n\nBe concise.",
+			expectedMsgLen: 1,
+		},
+		{
+			name: "no system messages",
+			messages: []common.Message{
+				{Role: "user", Content: "Hello"},
+				{Role: "assistant", Content: "Hi there!"},
+			},
+			expectedSystem: "",
+			expectedMsgLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := provider.BuildRequest(tt.messages, "claude-3-5-sonnet-latest", nil, slog.Default())
+
+			assert.NoError(t, err)
+			require.NotNil(t, request)
+
+			msgReq, ok := request.(*MessagesRequest)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.expectedSystem, msgReq.System)
+			assert.Len(t, msgReq.Messages, tt.expectedMsgLen)
+		})
+	}
+}
+
+func TestProvider_ParseResponse(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name            string
+		responseBody    string
+		expectedError   bool
+		expectedUsage   *common.Usage
+		expectedContent string
+	}{
+		{
+			name: "valid response",
+			responseBody: `{
+				"id": "msg_123",
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{
+						"type": "text",
+						"text": "Hello! I'm doing well, thank you for asking."
+					}
+				],
+				"model": "claude-3-5-sonnet-latest",
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 10,
+					"output_tokens": 15
+				}
+			}`,
+			expectedError: false,
+			expectedUsage: &common.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 15,
+				TotalTokens:      25,
+			},
+			expectedContent: "Hello! I'm doing well, thank you for asking.",
+		},
+		{
+			name: "multiple content items",
+			responseBody: `{
+				"id": "msg_123",
+				"type": "message",
+				"role": "assistant",
+				"content": [
+					{
+						"type": "text",
+						"text": "Hello! "
+					},
+					{
+						"type": "text",
+						"text": "How are you?"
+					}
+				],
+				"model": "claude-3-5-sonnet-latest",
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 5,
+					"output_tokens": 8
+				}
+			}`,
+			expectedError:   false,
+			expectedContent: "Hello! How are you?",
+		},
+		{
+			name:          "invalid JSON",
+			responseBody:  `{invalid json}`,
+			expectedError: true,
+		},
+		{
+			name: "no content",
+			responseBody: `{
+				"id": "msg_123",
+				"type": "message",
+				"role": "assistant",
+				"content": [],
+				"model": "claude-3-5-sonnet-latest",
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 10,
+					"output_tokens": 0
+				}
+			}`,
+			expectedError: true,
+		},
+		{
+			name: "no text content",
+			responseBody: `{
+				"id": "msg_123",
+				"type": "message", 
+				"role": "assistant",
+				"content": [
+					{
+						"type": "image",
+						"source": {}
+					}
+				],
+				"model": "claude-3-5-sonnet-latest",
+				"stop_reason": "end_turn",
+				"usage": {
+					"input_tokens": 10,
+					"output_tokens": 0
+				}
+			}`,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, usage, err := provider.ParseResponse([]byte(tt.responseBody), slog.Default())
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedContent, content)
+				if tt.expectedUsage != nil {
+					require.NotNil(t, usage)
+					assert.Equal(t, tt.expectedUsage.PromptTokens, usage.PromptTokens)
+					assert.Equal(t, tt.expectedUsage.CompletionTokens, usage.CompletionTokens)
+					assert.Equal(t, tt.expectedUsage.TotalTokens, usage.TotalTokens)
+				}
+			}
+		})
+	}
+}
+
+func TestProvider_HandleError(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		expectedSubstr string
+	}{
+		{
+			name:           "unauthorized",
+			statusCode:     http.StatusUnauthorized,
+			responseBody:   "",
+			expectedSubstr: "Anthropic API authentication failed",
+		},
+		{
+			name:           "rate limit exceeded",
+			statusCode:     http.StatusTooManyRequests,
+			responseBody:   "",
+			expectedSubstr: "Anthropic API rate limit exceeded",
+		},
+		{
+			name:           "structured error response",
+			statusCode:     http.StatusBadRequest,
+			responseBody:   `{"type": "error", "error": {"type": "invalid_request_error", "message": "Invalid request format"}}`,
+			expectedSubstr: "Anthropic API error: Invalid request format",
+		},
+		{
+			name:           "malformed error response",
+			statusCode:     http.StatusInternalServerError,
+			responseBody:   "Internal server error",
+			expectedSubstr: "Anthropic API request failed with status 500",
+		},
+		{
+			name:           "empty error message",
+			statusCode:     http.StatusBadRequest,
+			responseBody:   `{"type": "error", "error": {"type": "invalid_request_error", "message": ""}}`,
+			expectedSubstr: "an unknown API error occurred (status 400)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := provider.HandleError(tt.statusCode, []byte(tt.responseBody))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedSubstr)
+		})
+	}
+}
+
+func TestProvider_HandleConnectionError(t *testing.T) {
+	provider := New()
+	originalErr := assert.AnError
+
+	err := provider.HandleConnectionError(originalErr)
+	assert.Equal(t, originalErr, err)
+}
+
+func TestProvider_CustomizeRequest(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name         string
+		originalPath string
+		expectedPath string
+	}{
+		{
+			name:         "chat completions endpoint",
+			originalPath: "/chat/completions",
+			expectedPath: "/v1/messages",
+		},
+		{
+			name:         "v1 chat completions endpoint",
+			originalPath: "/v1/chat/completions",
+			expectedPath: "/v1/messages",
+		},
+		{
+			name:         "already correct endpoint",
+			originalPath: "/v1/messages",
+			expectedPath: "/v1/messages",
+		},
+		{
+			name:         "other endpoint",
+			originalPath: "/other/endpoint",
+			expectedPath: "/other/endpoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "https://api.anthropic.com"+tt.originalPath, nil)
+
+			err := provider.CustomizeRequest(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedPath, req.URL.Path)
+			assert.Equal(t, "2023-06-01", req.Header.Get("anthropic-version"))
+		})
+	}
+}
+
+func TestProvider_CustomizeRequest_AuthHeaders(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name               string
+		authHeader         string
+		expectedXAPIKey    string
+		expectedAuthHeader string
+	}{
+		{
+			name:               "Bearer token conversion",
+			authHeader:         "Bearer sk-ant-test123",
+			expectedXAPIKey:    "sk-ant-test123",
+			expectedAuthHeader: "",
+		},
+		{
+			name:               "No auth header",
+			authHeader:         "",
+			expectedXAPIKey:    "",
+			expectedAuthHeader: "",
+		},
+		{
+			name:               "Invalid auth header format",
+			authHeader:         "InvalidFormat test123",
+			expectedXAPIKey:    "",
+			expectedAuthHeader: "InvalidFormat test123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+
+			err := provider.CustomizeRequest(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedXAPIKey, req.Header.Get("x-api-key"))
+			assert.Equal(t, tt.expectedAuthHeader, req.Header.Get("Authorization"))
+			assert.Equal(t, "2023-06-01", req.Header.Get("anthropic-version"))
+		})
+	}
+}
+
+// Integration test with mock HTTP server
+func TestProvider_Integration(t *testing.T) {
+	// create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// verify request
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/v1/messages", r.URL.Path)
+		assert.Equal(t, "test-api-key", r.Header.Get("x-api-key"))
+		assert.Equal(t, "", r.Header.Get("Authorization")) // Should be removed
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "2023-06-01", r.Header.Get("anthropic-version"))
+
+		// parse request body
+		var reqBody MessagesRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.NoError(t, err)
+
+		assert.Equal(t, "claude-3-5-sonnet-latest", reqBody.Model)
+		assert.Len(t, reqBody.Messages, 1)
+		assert.Equal(t, "user", reqBody.Messages[0].Role)
+		assert.Equal(t, "test message", reqBody.Messages[0].Content)
+
+		// send response
+		response := MessagesResponse{
+			ID:   "msg_123",
+			Type: "message",
+			Role: "assistant",
+			Content: []ContentItem{
+				{
+					Type: "text",
+					Text: "test response",
+				},
+			},
+			Model:      "claude-3-5-sonnet-latest",
+			StopReason: "end_turn",
+			Usage: AnthropicUsage{
+				InputTokens:  5,
+				OutputTokens: 2,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// create provider with custom base URL
+	provider := New()
+	cfg := &config.Config{
+		Providers: config.Providers{
+			Anthropic: config.Anthropic{
+				BaseProvider: config.BaseProvider{
+					APIKey:  "test-api-key",
+					BaseUrl: server.URL,
+				},
+			},
+		},
+	}
+
+	// create client
+	client, err := provider.CreateClient(cfg, slog.Default())
+	require.NoError(t, err)
+
+	// test generation
+	messages := []common.Message{
+		{Role: "user", Content: "test message"},
+	}
+
+	content, err := client.Generate(context.Background(), messages, "claude-3-5-sonnet-latest")
+	require.NoError(t, err)
+	assert.Equal(t, "test response", content)
+}

--- a/internal/llm/groq/client.go
+++ b/internal/llm/groq/client.go
@@ -1,0 +1,19 @@
+package groq
+
+import "slop/internal/llm/common"
+
+// ChatRequest represents the request payload for Groq's chat API
+// Groq uses OpenAI-compatible format
+type ChatRequest struct {
+	Model            string                 `json:"model"`
+	Messages         []common.Message       `json:"messages"`
+	Temperature      *float64               `json:"temperature,omitempty"`
+	TopP             *float64               `json:"top_p,omitempty"`
+	MaxTokens        *int                   `json:"max_tokens,omitempty"`
+	Stream           *bool                  `json:"stream,omitempty"`
+	Stop             []string               `json:"stop,omitempty"`
+	FrequencyPenalty *float64               `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64               `json:"presence_penalty,omitempty"`
+	ResponseFormat   *common.ResponseFormat `json:"response_format,omitempty"`
+	Seed             *int                   `json:"seed,omitempty"`
+}

--- a/internal/llm/groq/options.go
+++ b/internal/llm/groq/options.go
@@ -1,0 +1,95 @@
+package groq
+
+import "slop/internal/llm/common"
+
+// GenerateOptions contains Groq-specific generation parameters
+type GenerateOptions struct {
+	common.GenerateOptions
+
+	// Groq-specific params (using OpenAI-compatible naming)
+	FrequencyPenalty *float64 // Number between -2.0 and 2.0
+	PresencePenalty  *float64 // Number between -2.0 and 2.0
+	Seed             *int     // Integer seed for deterministic outputs
+}
+
+// GenerateOption configures Groq-specific generation parameters
+type GenerateOption func(*GenerateOptions)
+
+// NewGenerateOptions creates new GenerateOptions with functional options applied
+func NewGenerateOptions(opts ...GenerateOption) *GenerateOptions {
+	config := &GenerateOptions{}
+	for _, opt := range opts {
+		opt(config)
+	}
+	return config
+}
+
+// WithFrequencyPenalty sets frequency penalty (-2.0 to 2.0)
+func WithFrequencyPenalty(penalty float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.FrequencyPenalty = &penalty
+	}
+}
+
+// WithPresencePenalty sets presence penalty (-2.0 to 2.0)
+func WithPresencePenalty(penalty float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.PresencePenalty = &penalty
+	}
+}
+
+// WithSeed enables deterministic generation using seed
+func WithSeed(seed int) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.Seed = &seed
+	}
+}
+
+// Common options
+
+// WithTemperature sets response randomness (0.0-2.0)
+func WithTemperature(temp float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithTemperature(temp)(&c.GenerateOptions)
+	}
+}
+
+// WithTopP sets nucleus sampling threshold (0.0-1.0)
+func WithTopP(topP float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithTopP(topP)(&c.GenerateOptions)
+	}
+}
+
+// WithMaxTokens sets maximum tokens to generate
+func WithMaxTokens(maxTokens int) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithMaxTokens(maxTokens)(&c.GenerateOptions)
+	}
+}
+
+// WithStop sets stop sequences to halt generation
+func WithStop(stop []string) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithStop(stop)(&c.GenerateOptions)
+	}
+}
+
+// WithJSONFormat enables JSON structured output
+func WithJSONFormat() GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithJSONFormat()(&c.GenerateOptions)
+	}
+}
+
+// WithResponseFormat sets structured output format
+func WithResponseFormat(format *common.ResponseFormat) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithResponseFormat(format)(&c.GenerateOptions)
+	}
+}
+
+// GetGenerateOptions returns the embedded common GenerateOptions for validation
+func (c *GenerateOptions) GetGenerateOptions() *common.GenerateOptions {
+	return &c.GenerateOptions
+}

--- a/internal/llm/groq/provider.go
+++ b/internal/llm/groq/provider.go
@@ -7,4 +7,221 @@
 //   client := groq.NewClient(apiKey)
 //   response, err := client.Generate(ctx, messages, groq.WithTemperature(0.7))
 //
-// Sample groq models include: llama-3.1-8b-instant, llama-3.3-70b-versatile, qwen/qwen3-32b
+// Groq models include: llama-3.3-70b-versatile, llama-3.1-8b-instant, mixtral-8x7b-32768
+
+package groq
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"slop/internal/config"
+	"slop/internal/llm/common"
+)
+
+// Provider implements the unified registry.Provider interface for Groq
+type Provider struct{}
+
+// ensure Provider implements the common.Provider interface
+var _ common.Provider = (*Provider)(nil)
+
+// New creates a new Groq provider instance
+func New() *Provider {
+	return &Provider{}
+}
+
+// CreateClient creates a new LLM client using the unified adapter pattern
+func (p *Provider) CreateClient(cfg *config.Config, logger *slog.Logger) (common.LLM, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	if cfg.Providers.Groq.APIKey == "" {
+		return nil, fmt.Errorf(`Groq API key is required.
+
+You can set the API key using the environment variable GROQ_API_KEY or via slop config set groq-key=<your_api_key>
+Get an API key from https://console.groq.com/keys`)
+	}
+
+	// create client options
+	var opts []common.ClientOption
+	if cfg.Providers.Groq.BaseUrl != "" {
+		opts = append(opts, common.WithBaseURL(cfg.Providers.Groq.BaseUrl))
+	}
+	if logger != nil {
+		opts = append(opts, common.WithLogger(logger))
+	}
+	maxRetries := cfg.Parameters.MaxRetries
+	if maxRetries > 5 {
+		maxRetries = 5 // enforce maximum limit
+	}
+	if maxRetries > 0 {
+		opts = append(opts, common.WithMaxRetries(maxRetries))
+	}
+
+	adapterClient := common.NewAdapterClient(p, cfg.Providers.Groq.APIKey, "https://api.groq.com/openai/v1", opts...)
+	return adapterClient, nil
+}
+
+// BuildOptions creates Groq-specific generation options from configuration
+func (p *Provider) BuildOptions(cfg *config.Config) []interface{} {
+	var functionalOpts []GenerateOption
+
+	if cfg.Parameters.Temperature > 0 {
+		functionalOpts = append(functionalOpts, WithTemperature(cfg.Parameters.Temperature))
+	}
+	if cfg.Parameters.MaxTokens > 0 {
+		functionalOpts = append(functionalOpts, WithMaxTokens(cfg.Parameters.MaxTokens))
+	}
+	if cfg.Parameters.TopP > 0 {
+		functionalOpts = append(functionalOpts, WithTopP(cfg.Parameters.TopP))
+	}
+	if len(cfg.Parameters.StopSequences) > 0 {
+		functionalOpts = append(functionalOpts, WithStop(cfg.Parameters.StopSequences))
+	}
+	if cfg.Parameters.Seed != nil {
+		functionalOpts = append(functionalOpts, WithSeed(*cfg.Parameters.Seed))
+	}
+	if cfg.Format.JSON {
+		functionalOpts = append(functionalOpts, WithJSONFormat())
+	}
+
+	return []interface{}{NewGenerateOptions(functionalOpts...)}
+}
+
+// RequiresAPIKey returns true since Groq requires an API key
+func (p *Provider) RequiresAPIKey() bool {
+	return true
+}
+
+// ProviderName returns the name of this provider
+func (p *Provider) ProviderName() string {
+	return "groq"
+}
+
+// BuildRequest creates a Groq-specific request from messages and options
+func (p *Provider) BuildRequest(messages []common.Message, modelName string, options interface{}, logger *slog.Logger) (interface{}, error) {
+	// convert options to Groq-specific options
+	var config *GenerateOptions
+	if options != nil {
+		if groqOpts, ok := options.(*GenerateOptions); ok {
+			config = groqOpts
+		} else {
+			config = &GenerateOptions{}
+		}
+	} else {
+		config = &GenerateOptions{}
+	}
+
+	// log the API request using common utilities
+	common.LogAPIRequest(logger, "Groq", modelName, messages, &config.GenerateOptions)
+
+	// create Groq-specific request payload
+	requestBody := &ChatRequest{
+		Model:    modelName,
+		Messages: messages,
+		Stream:   common.BoolPtr(false), // Disable streaming for now
+	}
+
+	// map common generation options to Groq's API format
+	if config.Temperature != nil {
+		requestBody.Temperature = config.Temperature
+	}
+	if config.MaxTokens != nil {
+		requestBody.MaxTokens = config.MaxTokens
+	}
+	if config.TopP != nil {
+		requestBody.TopP = config.TopP
+	}
+	if len(config.Stop) > 0 {
+		requestBody.Stop = config.Stop
+	}
+
+	// map Groq-specific options
+	if config.FrequencyPenalty != nil {
+		requestBody.FrequencyPenalty = config.FrequencyPenalty
+	}
+	if config.PresencePenalty != nil {
+		requestBody.PresencePenalty = config.PresencePenalty
+	}
+	if config.Seed != nil {
+		requestBody.Seed = config.Seed
+	}
+
+	// handle structured output if requested
+	if config.ResponseFormat != nil {
+		requestBody.ResponseFormat = &common.ResponseFormat{
+			Type: config.ResponseFormat.Type,
+		}
+	}
+
+	return requestBody, nil
+}
+
+// ParseResponse parses a Groq API response and extracts content and usage
+func (p *Provider) ParseResponse(body []byte, logger *slog.Logger) (string, *common.Usage, error) {
+	// parse the response using standard OpenAI-compatible format
+	var chatResp common.ChatResponse
+	if err := json.Unmarshal(body, &chatResp); err != nil {
+		common.LogJSONUnmarshalError(logger, err, string(body))
+		return "", nil, fmt.Errorf("failed to unmarshal Groq response: %w", err)
+	}
+
+	// extract content from the first choice
+	if len(chatResp.Choices) == 0 {
+		return "", nil, fmt.Errorf("no choices in Groq response")
+	}
+
+	content := chatResp.Choices[0].Message.Content
+
+	// return content and usage information
+	return content, &chatResp.Usage, nil
+}
+
+// HandleError creates Groq-specific error messages from HTTP error responses
+func (p *Provider) HandleError(statusCode int, body []byte) error {
+
+	// without the body, we can sometimes provide specific, actionable error messages
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf(`Groq API authentication failed.
+
+Check your API key and ensure it is set correctly. 
+You can set the API key using the environment variable GROQ_API_KEY or via slop config set groq-key=<your_api_key>
+Get an API key from https://console.groq.com/keys`)
+
+	case http.StatusTooManyRequests:
+		return fmt.Errorf(`Groq API rate limit exceeded.
+
+Please try again later or check your usage at https://console.groq.com/`)
+	}
+
+	// attempt to parse the structured JSON error from the response body
+	var errorResp common.ErrorResponse
+	if err := json.Unmarshal(body, &errorResp); err != nil {
+		// FALLBACK if the response was not the expected JSON format:
+		return fmt.Errorf("Groq API request failed with status %d: %s", statusCode, string(body))
+	}
+
+	// now we can return a much more helpful, specific error message!
+	if errorResp.Error.Message != "" {
+		return fmt.Errorf("Groq API error: %s", errorResp.Error.Message)
+	}
+
+	// final catch-all if parsing succeeded but the message was empty
+	return fmt.Errorf("an unknown API error occurred (status %d)", statusCode)
+}
+
+// HandleConnectionError handles connection failures - for cloud services, return original error
+func (p *Provider) HandleConnectionError(err error) error {
+	return err
+}
+
+// CustomizeRequest allows Groq to customize the HTTP request if needed
+func (p *Provider) CustomizeRequest(req *http.Request) error {
+	// no customization needed at this time
+	// this is implemented for completeness/future extensibility
+	return nil
+}

--- a/internal/llm/groq/provider_test.go
+++ b/internal/llm/groq/provider_test.go
@@ -1,0 +1,446 @@
+package groq
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"slop/internal/config"
+	"slop/internal/llm/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_Interface(t *testing.T) {
+	// verify that Provider implements the common.Provider interface
+	var _ common.Provider = (*Provider)(nil)
+}
+
+func TestNew(t *testing.T) {
+	provider := New()
+	assert.NotNil(t, provider)
+	assert.IsType(t, &Provider{}, provider)
+}
+
+func TestProvider_ProviderName(t *testing.T) {
+	provider := New()
+	assert.Equal(t, "groq", provider.ProviderName())
+}
+
+func TestProvider_RequiresAPIKey(t *testing.T) {
+	provider := New()
+	assert.True(t, provider.RequiresAPIKey())
+}
+
+func TestProvider_CreateClient(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name        string
+		config      *config.Config
+		expectError bool
+	}{
+		{
+			name:        "nil config",
+			config:      nil,
+			expectError: true,
+		},
+		{
+			name: "missing API key",
+			config: &config.Config{
+				Providers: config.Providers{
+					Groq: config.Groq{},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "valid config",
+			config: &config.Config{
+				Providers: config.Providers{
+					Groq: config.Groq{
+						BaseProvider: config.BaseProvider{
+							APIKey: "test-api-key",
+						},
+					},
+				},
+				Parameters: config.Parameters{
+					MaxRetries: 3,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "config with custom base URL",
+			config: &config.Config{
+				Providers: config.Providers{
+					Groq: config.Groq{
+						BaseProvider: config.BaseProvider{
+							APIKey:  "test-api-key",
+							BaseUrl: "https://custom.groq.com/v1",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := provider.CreateClient(tt.config, slog.Default())
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestProvider_BuildOptions(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name     string
+		config   *config.Config
+		expected int // expected number of options
+	}{
+		{
+			name: "minimal config",
+			config: &config.Config{
+				Parameters: config.Parameters{},
+				Format:     config.Format{},
+			},
+			expected: 1, // always returns at least one GenerateOptions object
+		},
+		{
+			name: "full config",
+			config: &config.Config{
+				Parameters: config.Parameters{
+					Temperature:   0.7,
+					MaxTokens:     1000,
+					TopP:          0.9,
+					StopSequences: []string{"end", "stop"},
+					Seed:          common.IntPtr(42),
+				},
+				Format: config.Format{
+					JSON: true,
+				},
+			},
+			expected: 1, // still returns one GenerateOptions object, but with all options set
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := provider.BuildOptions(tt.config)
+			assert.Len(t, options, tt.expected)
+
+			// verify the first option is a GenerateOptions
+			if len(options) > 0 {
+				generateOpts, ok := options[0].(*GenerateOptions)
+				assert.True(t, ok)
+				assert.NotNil(t, generateOpts)
+			}
+		})
+	}
+}
+
+func TestProvider_BuildRequest(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Hello, how are you?"},
+	}
+	modelName := "llama-3.1-8b-instant"
+
+	tests := []struct {
+		name     string
+		options  interface{}
+		expected *ChatRequest
+	}{
+		{
+			name:    "nil options",
+			options: nil,
+			expected: &ChatRequest{
+				Model:    modelName,
+				Messages: messages,
+				Stream:   common.BoolPtr(false),
+			},
+		},
+		{
+			name: "with generate options",
+			options: NewGenerateOptions(
+				WithTemperature(0.7),
+				WithMaxTokens(1000),
+				WithFrequencyPenalty(0.5),
+				WithSeed(42),
+			),
+			expected: &ChatRequest{
+				Model:            modelName,
+				Messages:         messages,
+				Temperature:      common.Float64Ptr(0.7),
+				MaxTokens:        common.IntPtr(1000),
+				FrequencyPenalty: common.Float64Ptr(0.5),
+				Seed:             common.IntPtr(42),
+				Stream:           common.BoolPtr(false),
+			},
+		},
+		{
+			name:    "invalid options type",
+			options: "invalid",
+			expected: &ChatRequest{
+				Model:    modelName,
+				Messages: messages,
+				Stream:   common.BoolPtr(false),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := provider.BuildRequest(messages, modelName, tt.options, slog.Default())
+
+			assert.NoError(t, err)
+			assert.NotNil(t, request)
+
+			chatReq, ok := request.(*ChatRequest)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.expected.Model, chatReq.Model)
+			assert.Equal(t, tt.expected.Messages, chatReq.Messages)
+			assert.Equal(t, tt.expected.Stream, chatReq.Stream)
+
+			if tt.expected.Temperature != nil {
+				require.NotNil(t, chatReq.Temperature)
+				assert.Equal(t, *tt.expected.Temperature, *chatReq.Temperature)
+			}
+			if tt.expected.MaxTokens != nil {
+				require.NotNil(t, chatReq.MaxTokens)
+				assert.Equal(t, *tt.expected.MaxTokens, *chatReq.MaxTokens)
+			}
+			if tt.expected.FrequencyPenalty != nil {
+				require.NotNil(t, chatReq.FrequencyPenalty)
+				assert.Equal(t, *tt.expected.FrequencyPenalty, *chatReq.FrequencyPenalty)
+			}
+			if tt.expected.Seed != nil {
+				require.NotNil(t, chatReq.Seed)
+				assert.Equal(t, *tt.expected.Seed, *chatReq.Seed)
+			}
+		})
+	}
+}
+
+func TestProvider_ParseResponse(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name            string
+		responseBody    string
+		expectedError   bool
+		expectedUsage   *common.Usage
+		expectedContent string
+	}{
+		{
+			name: "valid response",
+			responseBody: `{
+				"choices": [
+					{
+						"message": {
+							"content": "Hello! I'm doing well, thank you for asking."
+						}
+					}
+				],
+				"usage": {
+					"prompt_tokens": 10,
+					"completion_tokens": 15,
+					"total_tokens": 25
+				}
+			}`,
+			expectedError: false,
+			expectedUsage: &common.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 15,
+				TotalTokens:      25,
+			},
+			expectedContent: "Hello! I'm doing well, thank you for asking.",
+		},
+		{
+			name:          "invalid JSON",
+			responseBody:  `{invalid json}`,
+			expectedError: true,
+		},
+		{
+			name: "no choices",
+			responseBody: `{
+				"choices": [],
+				"usage": {
+					"prompt_tokens": 10,
+					"completion_tokens": 0,
+					"total_tokens": 10
+				}
+			}`,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, usage, err := provider.ParseResponse([]byte(tt.responseBody), slog.Default())
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedContent, content)
+				if tt.expectedUsage != nil {
+					require.NotNil(t, usage)
+					assert.Equal(t, tt.expectedUsage.PromptTokens, usage.PromptTokens)
+					assert.Equal(t, tt.expectedUsage.CompletionTokens, usage.CompletionTokens)
+					assert.Equal(t, tt.expectedUsage.TotalTokens, usage.TotalTokens)
+				}
+			}
+		})
+	}
+}
+
+func TestProvider_HandleError(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		expectedSubstr string
+	}{
+		{
+			name:           "unauthorized",
+			statusCode:     http.StatusUnauthorized,
+			responseBody:   "",
+			expectedSubstr: "Groq API authentication failed",
+		},
+		{
+			name:           "rate limit exceeded",
+			statusCode:     http.StatusTooManyRequests,
+			responseBody:   "",
+			expectedSubstr: "Groq API rate limit exceeded",
+		},
+		{
+			name:           "structured error response",
+			statusCode:     http.StatusBadRequest,
+			responseBody:   `{"error": {"message": "Invalid request format"}}`,
+			expectedSubstr: "Groq API error: Invalid request format",
+		},
+		{
+			name:           "malformed error response",
+			statusCode:     http.StatusInternalServerError,
+			responseBody:   "Internal server error",
+			expectedSubstr: "Groq API request failed with status 500",
+		},
+		{
+			name:           "empty error message",
+			statusCode:     http.StatusBadRequest,
+			responseBody:   `{"error": {"message": ""}}`,
+			expectedSubstr: "an unknown API error occurred (status 400)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := provider.HandleError(tt.statusCode, []byte(tt.responseBody))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedSubstr)
+		})
+	}
+}
+
+func TestProvider_HandleConnectionError(t *testing.T) {
+	provider := New()
+	originalErr := assert.AnError
+
+	err := provider.HandleConnectionError(originalErr)
+	assert.Equal(t, originalErr, err)
+}
+
+func TestProvider_CustomizeRequest(t *testing.T) {
+	provider := New()
+	req := httptest.NewRequest("POST", "https://api.groq.com/openai/v1/chat/completions", nil)
+
+	err := provider.CustomizeRequest(req)
+	assert.NoError(t, err)
+}
+
+// Integration test with mock HTTP server
+func TestProvider_Integration(t *testing.T) {
+	// create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// verify request
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/chat/completions", r.URL.Path)
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// parse request body
+		var reqBody ChatRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.NoError(t, err)
+
+		assert.Equal(t, "llama-3.1-8b-instant", reqBody.Model)
+		assert.Len(t, reqBody.Messages, 1)
+		assert.Equal(t, "user", reqBody.Messages[0].Role)
+		assert.Equal(t, "test message", reqBody.Messages[0].Content)
+
+		// send response
+		response := common.ChatResponse{
+			Choices: []common.Choice{
+				{
+					Message: common.Message{
+						Content: "test response",
+					},
+				},
+			},
+			Usage: common.Usage{
+				PromptTokens:     5,
+				CompletionTokens: 2,
+				TotalTokens:      7,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// create provider with custom base URL
+	provider := New()
+	cfg := &config.Config{
+		Providers: config.Providers{
+			Groq: config.Groq{
+				BaseProvider: config.BaseProvider{
+					APIKey:  "test-api-key",
+					BaseUrl: server.URL,
+				},
+			},
+		},
+	}
+
+	// create client
+	client, err := provider.CreateClient(cfg, slog.Default())
+	require.NoError(t, err)
+
+	// test generation
+	messages := []common.Message{
+		{Role: "user", Content: "test message"},
+	}
+
+	content, err := client.Generate(context.Background(), messages, "llama-3.1-8b-instant")
+	require.NoError(t, err)
+	assert.Equal(t, "test response", content)
+}

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -1,0 +1,33 @@
+package openai
+
+import "slop/internal/llm/common"
+
+// ChatRequest represents the request payload for OpenAI's chat API
+type ChatRequest struct {
+	Model               string                 `json:"model"`
+	Messages            []common.Message       `json:"messages"`
+	Temperature         *float64               `json:"temperature,omitempty"`
+	TopP                *float64               `json:"top_p,omitempty"`
+	MaxCompletionTokens *int                   `json:"max_completion_tokens,omitempty"`
+	Stream              *bool                  `json:"stream,omitempty"`
+	Stop                []string               `json:"stop,omitempty"`
+	FrequencyPenalty    *float64               `json:"frequency_penalty,omitempty"`
+	PresencePenalty     *float64               `json:"presence_penalty,omitempty"`
+	ResponseFormat      *common.ResponseFormat `json:"response_format,omitempty"`
+	Seed                *int                   `json:"seed,omitempty"`
+	Tools               []Tool                 `json:"tools,omitempty"`
+	ToolChoice          interface{}            `json:"tool_choice,omitempty"`
+}
+
+// Tool represents an OpenAI function tool
+type Tool struct {
+	Type     string   `json:"type"`
+	Function Function `json:"function"`
+}
+
+// Function represents an OpenAI function definition
+type Function struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Parameters  interface{} `json:"parameters,omitempty"`
+}

--- a/internal/llm/openai/options.go
+++ b/internal/llm/openai/options.go
@@ -1,0 +1,111 @@
+package openai
+
+import "slop/internal/llm/common"
+
+// GenerateOptions contains OpenAI-specific generation parameters
+type GenerateOptions struct {
+	common.GenerateOptions
+
+	// OpenAI-specific params
+	FrequencyPenalty *float64    // Number between -2.0 and 2.0
+	PresencePenalty  *float64    // Number between -2.0 and 2.0
+	Seed             *int        // Integer seed for deterministic outputs
+	Tools            []Tool      // Function calling tools
+	ToolChoice       interface{} // "none", "auto", or specific tool choice
+}
+
+// GenerateOption configures OpenAI-specific generation parameters
+type GenerateOption func(*GenerateOptions)
+
+// NewGenerateOptions creates new GenerateOptions with functional options applied
+func NewGenerateOptions(opts ...GenerateOption) *GenerateOptions {
+	config := &GenerateOptions{}
+	for _, opt := range opts {
+		opt(config)
+	}
+	return config
+}
+
+// WithFrequencyPenalty sets frequency penalty (-2.0 to 2.0)
+func WithFrequencyPenalty(penalty float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.FrequencyPenalty = &penalty
+	}
+}
+
+// WithPresencePenalty sets presence penalty (-2.0 to 2.0)
+func WithPresencePenalty(penalty float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.PresencePenalty = &penalty
+	}
+}
+
+// WithSeed enables deterministic generation using seed
+func WithSeed(seed int) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.Seed = &seed
+	}
+}
+
+// WithTools sets function calling tools
+func WithTools(tools []Tool) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.Tools = tools
+	}
+}
+
+// WithToolChoice sets tool choice strategy
+func WithToolChoice(choice interface{}) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.ToolChoice = choice
+	}
+}
+
+// Common options
+
+// WithTemperature sets response randomness (0.0-2.0)
+func WithTemperature(temp float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithTemperature(temp)(&c.GenerateOptions)
+	}
+}
+
+// WithTopP sets nucleus sampling threshold (0.0-1.0)
+func WithTopP(topP float64) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithTopP(topP)(&c.GenerateOptions)
+	}
+}
+
+// WithMaxTokens sets maximum tokens to generate
+func WithMaxTokens(maxTokens int) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithMaxTokens(maxTokens)(&c.GenerateOptions)
+	}
+}
+
+// WithStop sets stop sequences to halt generation
+func WithStop(stop []string) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithStop(stop)(&c.GenerateOptions)
+	}
+}
+
+// WithJSONFormat enables JSON structured output
+func WithJSONFormat() GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithJSONFormat()(&c.GenerateOptions)
+	}
+}
+
+// WithResponseFormat sets structured output format
+func WithResponseFormat(format *common.ResponseFormat) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithResponseFormat(format)(&c.GenerateOptions)
+	}
+}
+
+// GetGenerateOptions returns the embedded common GenerateOptions for validation
+func (c *GenerateOptions) GetGenerateOptions() *common.GenerateOptions {
+	return &c.GenerateOptions
+}

--- a/internal/llm/openai/provider.go
+++ b/internal/llm/openai/provider.go
@@ -9,3 +9,226 @@
 //
 // OpenAI models include: gpt-4.1-2025-04-14, o4-mini-2025-04-16, o3-2025-04-16
 // OpenAI model documentation: https://platform.openai.com/docs/models
+
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"slop/internal/config"
+	"slop/internal/llm/common"
+)
+
+// Provider implements the unified registry.Provider interface for OpenAI
+type Provider struct{}
+
+// ensure Provider implements the common.Provider interface
+var _ common.Provider = (*Provider)(nil)
+
+// New creates a new OpenAI provider instance
+func New() *Provider {
+	return &Provider{}
+}
+
+// CreateClient creates a new LLM client using the unified adapter pattern
+func (p *Provider) CreateClient(cfg *config.Config, logger *slog.Logger) (common.LLM, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	if cfg.Providers.OpenAI.APIKey == "" {
+		return nil, fmt.Errorf(`OpenAI API key is required.
+
+You can set the API key using the environment variable OPENAI_API_KEY or via slop config set openai-key=<your_api_key>
+Get an API key from https://platform.openai.com/api-keys`)
+	}
+
+	// create client options
+	var opts []common.ClientOption
+	if cfg.Providers.OpenAI.BaseUrl != "" {
+		opts = append(opts, common.WithBaseURL(cfg.Providers.OpenAI.BaseUrl))
+	}
+	if logger != nil {
+		opts = append(opts, common.WithLogger(logger))
+	}
+	maxRetries := cfg.Parameters.MaxRetries
+	if maxRetries > 5 {
+		maxRetries = 5 // enforce maximum limit
+	}
+	if maxRetries > 0 {
+		opts = append(opts, common.WithMaxRetries(maxRetries))
+	}
+
+	adapterClient := common.NewAdapterClient(p, cfg.Providers.OpenAI.APIKey, "https://api.openai.com/v1", opts...)
+	return adapterClient, nil
+}
+
+// BuildOptions creates OpenAI-specific generation options from configuration
+func (p *Provider) BuildOptions(cfg *config.Config) []interface{} {
+	var functionalOpts []GenerateOption
+
+	if cfg.Parameters.Temperature > 0 {
+		functionalOpts = append(functionalOpts, WithTemperature(cfg.Parameters.Temperature))
+	}
+	if cfg.Parameters.MaxTokens > 0 {
+		functionalOpts = append(functionalOpts, WithMaxTokens(cfg.Parameters.MaxTokens))
+	}
+	if cfg.Parameters.TopP > 0 {
+		functionalOpts = append(functionalOpts, WithTopP(cfg.Parameters.TopP))
+	}
+	if len(cfg.Parameters.StopSequences) > 0 {
+		functionalOpts = append(functionalOpts, WithStop(cfg.Parameters.StopSequences))
+	}
+	if cfg.Parameters.Seed != nil {
+		functionalOpts = append(functionalOpts, WithSeed(*cfg.Parameters.Seed))
+	}
+	if cfg.Format.JSON {
+		functionalOpts = append(functionalOpts, WithJSONFormat())
+	}
+
+	return []interface{}{NewGenerateOptions(functionalOpts...)}
+}
+
+// RequiresAPIKey returns true since OpenAI requires an API key
+func (p *Provider) RequiresAPIKey() bool {
+	return true
+}
+
+// ProviderName returns the name of this provider
+func (p *Provider) ProviderName() string {
+	return "openai"
+}
+
+// BuildRequest creates an OpenAI-specific request from messages and options
+func (p *Provider) BuildRequest(messages []common.Message, modelName string, options interface{}, logger *slog.Logger) (interface{}, error) {
+	// convert options to OpenAI-specific options
+	var config *GenerateOptions
+	if options != nil {
+		if openaiOpts, ok := options.(*GenerateOptions); ok {
+			config = openaiOpts
+		} else {
+			config = &GenerateOptions{}
+		}
+	} else {
+		config = &GenerateOptions{}
+	}
+
+	// log the API request using common utilities
+	common.LogAPIRequest(logger, "OpenAI", modelName, messages, &config.GenerateOptions)
+
+	// create OpenAI-specific request payload
+	requestBody := &ChatRequest{
+		Model:    modelName,
+		Messages: messages,
+		Stream:   common.BoolPtr(false), // Disable streaming for now
+	}
+
+	// map common generation options to OpenAI's API format
+	if config.Temperature != nil {
+		requestBody.Temperature = config.Temperature
+	}
+	if config.MaxTokens != nil {
+		requestBody.MaxCompletionTokens = config.MaxTokens
+	}
+	if config.TopP != nil {
+		requestBody.TopP = config.TopP
+	}
+	if len(config.Stop) > 0 {
+		requestBody.Stop = config.Stop
+	}
+
+	// map OpenAI-specific options
+	if config.FrequencyPenalty != nil {
+		requestBody.FrequencyPenalty = config.FrequencyPenalty
+	}
+	if config.PresencePenalty != nil {
+		requestBody.PresencePenalty = config.PresencePenalty
+	}
+	if config.Seed != nil {
+		requestBody.Seed = config.Seed
+	}
+	if len(config.Tools) > 0 {
+		requestBody.Tools = config.Tools
+	}
+	if config.ToolChoice != nil {
+		requestBody.ToolChoice = config.ToolChoice
+	}
+
+	// handle structured output if requested
+	if config.ResponseFormat != nil {
+		requestBody.ResponseFormat = &common.ResponseFormat{
+			Type: config.ResponseFormat.Type,
+		}
+	}
+
+	return requestBody, nil
+}
+
+// ParseResponse parses an OpenAI API response and extracts content and usage
+func (p *Provider) ParseResponse(body []byte, logger *slog.Logger) (string, *common.Usage, error) {
+	// parse the response using standard OpenAI format
+	var chatResp common.ChatResponse
+	if err := json.Unmarshal(body, &chatResp); err != nil {
+		common.LogJSONUnmarshalError(logger, err, string(body))
+		return "", nil, fmt.Errorf("failed to unmarshal OpenAI response: %w", err)
+	}
+
+	// extract content from the first choice
+	if len(chatResp.Choices) == 0 {
+		return "", nil, fmt.Errorf("no choices in OpenAI response")
+	}
+
+	content := chatResp.Choices[0].Message.Content
+
+	// return content and usage information
+	return content, &chatResp.Usage, nil
+}
+
+// HandleError creates OpenAI-specific error messages from HTTP error responses
+func (p *Provider) HandleError(statusCode int, body []byte) error {
+
+	// without the body, we can sometimes provide specific, actionable error messages
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf(`OpenAI API authentication failed.
+
+Check your API key and ensure it is set correctly. 
+You can set the API key using the environment variable OPENAI_API_KEY or via slop config set openai-key=<your_api_key>
+Get an API key from https://platform.openai.com/api-keys`)
+
+	case http.StatusTooManyRequests:
+		return fmt.Errorf(`OpenAI API rate limit exceeded.
+
+Please try again later or check your usage at https://platform.openai.com/usage`)
+	}
+
+	// attempt to parse the structured JSON error from the response body
+	var errorResp common.ErrorResponse
+	if err := json.Unmarshal(body, &errorResp); err != nil {
+		// FALLBACK if the response was not the expected JSON format:
+		return fmt.Errorf("OpenAI API request failed with status %d: %s", statusCode, string(body))
+	}
+
+	// now we can return a much more helpful, specific error message!
+	if errorResp.Error.Message != "" {
+		return fmt.Errorf("OpenAI API error: %s", errorResp.Error.Message)
+	}
+
+	// final catch-all if parsing succeeded but the message was empty
+	return fmt.Errorf("an unknown API error occurred (status %d)", statusCode)
+}
+
+// HandleConnectionError handles connection failures - for cloud services, return original error
+func (p *Provider) HandleConnectionError(err error) error {
+	return err
+}
+
+// CustomizeRequest allows OpenAI to customize the HTTP request if needed
+func (p *Provider) CustomizeRequest(req *http.Request) error {
+	// no customization needed at this time
+	// this is implemented for completeness/future extensibility
+	return nil
+}

--- a/internal/llm/openai/provider_test.go
+++ b/internal/llm/openai/provider_test.go
@@ -1,0 +1,467 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"slop/internal/config"
+	"slop/internal/llm/common"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_Interface(t *testing.T) {
+	// verify that Provider implements the common.Provider interface
+	var _ common.Provider = (*Provider)(nil)
+}
+
+func TestNew(t *testing.T) {
+	provider := New()
+	assert.NotNil(t, provider)
+	assert.IsType(t, &Provider{}, provider)
+}
+
+func TestProvider_ProviderName(t *testing.T) {
+	provider := New()
+	assert.Equal(t, "openai", provider.ProviderName())
+}
+
+func TestProvider_RequiresAPIKey(t *testing.T) {
+	provider := New()
+	assert.True(t, provider.RequiresAPIKey())
+}
+
+func TestProvider_CreateClient(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name        string
+		config      *config.Config
+		expectError bool
+	}{
+		{
+			name:        "nil config",
+			config:      nil,
+			expectError: true,
+		},
+		{
+			name: "missing API key",
+			config: &config.Config{
+				Providers: config.Providers{
+					OpenAI: config.OpenAI{},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "valid config",
+			config: &config.Config{
+				Providers: config.Providers{
+					OpenAI: config.OpenAI{
+						BaseProvider: config.BaseProvider{
+							APIKey: "test-api-key",
+						},
+					},
+				},
+				Parameters: config.Parameters{
+					MaxRetries: 3,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "config with custom base URL",
+			config: &config.Config{
+				Providers: config.Providers{
+					OpenAI: config.OpenAI{
+						BaseProvider: config.BaseProvider{
+							APIKey:  "test-api-key",
+							BaseUrl: "https://custom.openai.com/v1",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := provider.CreateClient(tt.config, slog.Default())
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestProvider_BuildOptions(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name     string
+		config   *config.Config
+		expected int // expected number of options
+	}{
+		{
+			name: "minimal config",
+			config: &config.Config{
+				Parameters: config.Parameters{},
+				Format:     config.Format{},
+			},
+			expected: 1, // always returns at least one GenerateOptions object
+		},
+		{
+			name: "full config",
+			config: &config.Config{
+				Parameters: config.Parameters{
+					Temperature:   0.7,
+					MaxTokens:     1000,
+					TopP:          0.9,
+					StopSequences: []string{"end", "stop"},
+					Seed:          common.IntPtr(42),
+				},
+				Format: config.Format{
+					JSON: true,
+				},
+			},
+			expected: 1, // still returns one GenerateOptions object, but with all options set
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := provider.BuildOptions(tt.config)
+			assert.Len(t, options, tt.expected)
+
+			// verify the first option is a GenerateOptions
+			if len(options) > 0 {
+				generateOpts, ok := options[0].(*GenerateOptions)
+				assert.True(t, ok)
+				assert.NotNil(t, generateOpts)
+			}
+		})
+	}
+}
+
+func TestProvider_BuildRequest(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Hello, how are you?"},
+	}
+	modelName := "gpt-4"
+
+	tests := []struct {
+		name     string
+		options  interface{}
+		expected *ChatRequest
+	}{
+		{
+			name:    "nil options",
+			options: nil,
+			expected: &ChatRequest{
+				Model:    modelName,
+				Messages: messages,
+				Stream:   common.BoolPtr(false),
+			},
+		},
+		{
+			name: "with generate options",
+			options: NewGenerateOptions(
+				WithTemperature(0.7),
+				WithMaxTokens(1000),
+				WithFrequencyPenalty(0.5),
+				WithSeed(42),
+				WithTools([]Tool{
+					{
+						Type: "function",
+						Function: Function{
+							Name:        "test_function",
+							Description: "A test function",
+						},
+					},
+				}),
+			),
+			expected: &ChatRequest{
+				Model:               modelName,
+				Messages:            messages,
+				Temperature:         common.Float64Ptr(0.7),
+				MaxCompletionTokens: common.IntPtr(1000),
+				FrequencyPenalty:    common.Float64Ptr(0.5),
+				Seed:                common.IntPtr(42),
+				Tools: []Tool{
+					{
+						Type: "function",
+						Function: Function{
+							Name:        "test_function",
+							Description: "A test function",
+						},
+					},
+				},
+				Stream: common.BoolPtr(false),
+			},
+		},
+		{
+			name:    "invalid options type",
+			options: "invalid",
+			expected: &ChatRequest{
+				Model:    modelName,
+				Messages: messages,
+				Stream:   common.BoolPtr(false),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := provider.BuildRequest(messages, modelName, tt.options, slog.Default())
+
+			assert.NoError(t, err)
+			assert.NotNil(t, request)
+
+			chatReq, ok := request.(*ChatRequest)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.expected.Model, chatReq.Model)
+			assert.Equal(t, tt.expected.Messages, chatReq.Messages)
+			assert.Equal(t, tt.expected.Stream, chatReq.Stream)
+
+			if tt.expected.Temperature != nil {
+				require.NotNil(t, chatReq.Temperature)
+				assert.Equal(t, *tt.expected.Temperature, *chatReq.Temperature)
+			}
+			if tt.expected.MaxCompletionTokens != nil {
+				require.NotNil(t, chatReq.MaxCompletionTokens)
+				assert.Equal(t, *tt.expected.MaxCompletionTokens, *chatReq.MaxCompletionTokens)
+			}
+			if tt.expected.FrequencyPenalty != nil {
+				require.NotNil(t, chatReq.FrequencyPenalty)
+				assert.Equal(t, *tt.expected.FrequencyPenalty, *chatReq.FrequencyPenalty)
+			}
+			if tt.expected.Seed != nil {
+				require.NotNil(t, chatReq.Seed)
+				assert.Equal(t, *tt.expected.Seed, *chatReq.Seed)
+			}
+			if len(tt.expected.Tools) > 0 {
+				assert.Equal(t, tt.expected.Tools, chatReq.Tools)
+			}
+		})
+	}
+}
+
+func TestProvider_ParseResponse(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name            string
+		responseBody    string
+		expectedError   bool
+		expectedUsage   *common.Usage
+		expectedContent string
+	}{
+		{
+			name: "valid response",
+			responseBody: `{
+				"choices": [
+					{
+						"message": {
+							"content": "Hello! I'm doing well, thank you for asking."
+						}
+					}
+				],
+				"usage": {
+					"prompt_tokens": 10,
+					"completion_tokens": 15,
+					"total_tokens": 25
+				}
+			}`,
+			expectedError: false,
+			expectedUsage: &common.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 15,
+				TotalTokens:      25,
+			},
+			expectedContent: "Hello! I'm doing well, thank you for asking.",
+		},
+		{
+			name:          "invalid JSON",
+			responseBody:  `{invalid json}`,
+			expectedError: true,
+		},
+		{
+			name: "no choices",
+			responseBody: `{
+				"choices": [],
+				"usage": {
+					"prompt_tokens": 10,
+					"completion_tokens": 0,
+					"total_tokens": 10
+				}
+			}`,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, usage, err := provider.ParseResponse([]byte(tt.responseBody), slog.Default())
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedContent, content)
+				if tt.expectedUsage != nil {
+					require.NotNil(t, usage)
+					assert.Equal(t, tt.expectedUsage.PromptTokens, usage.PromptTokens)
+					assert.Equal(t, tt.expectedUsage.CompletionTokens, usage.CompletionTokens)
+					assert.Equal(t, tt.expectedUsage.TotalTokens, usage.TotalTokens)
+				}
+			}
+		})
+	}
+}
+
+func TestProvider_HandleError(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		expectedSubstr string
+	}{
+		{
+			name:           "unauthorized",
+			statusCode:     http.StatusUnauthorized,
+			responseBody:   "",
+			expectedSubstr: "OpenAI API authentication failed",
+		},
+		{
+			name:           "rate limit exceeded",
+			statusCode:     http.StatusTooManyRequests,
+			responseBody:   "",
+			expectedSubstr: "OpenAI API rate limit exceeded",
+		},
+		{
+			name:           "structured error response",
+			statusCode:     http.StatusBadRequest,
+			responseBody:   `{"error": {"message": "Invalid request format"}}`,
+			expectedSubstr: "OpenAI API error: Invalid request format",
+		},
+		{
+			name:           "malformed error response",
+			statusCode:     http.StatusInternalServerError,
+			responseBody:   "Internal server error",
+			expectedSubstr: "OpenAI API request failed with status 500",
+		},
+		{
+			name:           "empty error message",
+			statusCode:     http.StatusBadRequest,
+			responseBody:   `{"error": {"message": ""}}`,
+			expectedSubstr: "an unknown API error occurred (status 400)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := provider.HandleError(tt.statusCode, []byte(tt.responseBody))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedSubstr)
+		})
+	}
+}
+
+func TestProvider_HandleConnectionError(t *testing.T) {
+	provider := New()
+	originalErr := assert.AnError
+
+	err := provider.HandleConnectionError(originalErr)
+	assert.Equal(t, originalErr, err)
+}
+
+func TestProvider_CustomizeRequest(t *testing.T) {
+	provider := New()
+	req := httptest.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+
+	err := provider.CustomizeRequest(req)
+	assert.NoError(t, err)
+}
+
+// Integration test with mock HTTP server
+func TestProvider_Integration(t *testing.T) {
+	// create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// verify request
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/chat/completions", r.URL.Path)
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// parse request body
+		var reqBody ChatRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.NoError(t, err)
+
+		assert.Equal(t, "gpt-4", reqBody.Model)
+		assert.Len(t, reqBody.Messages, 1)
+		assert.Equal(t, "user", reqBody.Messages[0].Role)
+		assert.Equal(t, "test message", reqBody.Messages[0].Content)
+
+		// send response
+		response := common.ChatResponse{
+			Choices: []common.Choice{
+				{
+					Message: common.Message{
+						Content: "test response",
+					},
+				},
+			},
+			Usage: common.Usage{
+				PromptTokens:     5,
+				CompletionTokens: 2,
+				TotalTokens:      7,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// create provider with custom base URL
+	provider := New()
+	cfg := &config.Config{
+		Providers: config.Providers{
+			OpenAI: config.OpenAI{
+				BaseProvider: config.BaseProvider{
+					APIKey:  "test-api-key",
+					BaseUrl: server.URL,
+				},
+			},
+		},
+	}
+
+	// create client
+	client, err := provider.CreateClient(cfg, slog.Default())
+	require.NoError(t, err)
+
+	// test generation
+	messages := []common.Message{
+		{Role: "user", Content: "test message"},
+	}
+
+	content, err := client.Generate(context.Background(), messages, "gpt-4")
+	require.NoError(t, err)
+	assert.Equal(t, "test response", content)
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,20 +5,26 @@ import (
 	"log/slog"
 
 	"slop/internal/config"
+	"slop/internal/llm/anthropic"
 	"slop/internal/llm/cohere"
 	"slop/internal/llm/common"
+	"slop/internal/llm/groq"
 	"slop/internal/llm/mistral"
 	"slop/internal/llm/mock"
 	"slop/internal/llm/ollama"
+	"slop/internal/llm/openai"
 )
 
 // AllProviders contains registered LLM providers
 // TODO this is manually updated for now
 var AllProviders = map[string]common.Provider{
-	"cohere":  cohere.New(),
-	"mistral": mistral.New(),
-	"mock":    mock.New(),
-	"ollama":  ollama.New(),
+	"anthropic": anthropic.New(),
+	"cohere":    cohere.New(),
+	"groq":      groq.New(),
+	"mistral":   mistral.New(),
+	"mock":      mock.New(),
+	"ollama":    ollama.New(),
+	"openai":    openai.New(),
 }
 
 // CreateProvider creates a provider instance using the central registry

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -95,7 +95,7 @@ func TestAllProvidersInitialization(t *testing.T) {
 	})
 
 	t.Run("Contains expected provider keys", func(t *testing.T) {
-		expectedProviders := []string{"cohere", "mistral", "ollama"}
+		expectedProviders := []string{"anthropic", "cohere", "groq", "mistral", "ollama", "openai"}
 
 		for _, providerName := range expectedProviders {
 			assert.Contains(t, AllProviders, providerName, "AllProviders should contain %s", providerName)
@@ -322,7 +322,7 @@ func TestGetAvailableProviders(t *testing.T) {
 	assert.NotEmpty(t, providers)
 
 	// check that expected providers are present
-	expectedProviders := []string{"cohere", "mistral", "ollama"}
+	expectedProviders := []string{"anthropic", "cohere", "groq", "mistral", "ollama", "openai"}
 	for _, expected := range expectedProviders {
 		assert.Contains(t, providers, expected)
 	}
@@ -347,6 +347,21 @@ func TestIsProviderRegistered(t *testing.T) {
 		{
 			name:         "Registered provider - ollama",
 			providerName: "ollama",
+			expected:     true,
+		},
+		{
+			name:         "Registered provider - anthropic",
+			providerName: "anthropic",
+			expected:     true,
+		},
+		{
+			name:         "Registered provider - openai",
+			providerName: "openai",
+			expected:     true,
+		},
+		{
+			name:         "Registered provider - groq",
+			providerName: "groq",
 			expected:     true,
 		},
 		{
@@ -389,6 +404,21 @@ func TestProviderRequiresAPIKey(t *testing.T) {
 			name:         "Ollama does not require API key",
 			providerName: "ollama",
 			expected:     false,
+		},
+		{
+			name:         "Anthropic requires API key",
+			providerName: "anthropic",
+			expected:     true,
+		},
+		{
+			name:         "OpenAI requires API key",
+			providerName: "openai",
+			expected:     true,
+		},
+		{
+			name:         "Groq requires API key",
+			providerName: "groq",
+			expected:     true,
 		},
 		{
 			name:         "Unknown provider defaults to false",


### PR DESCRIPTION
This PR adds support for three major LLM providers to slop: OpenAI, Anthropic, and Groq. All providers follow the unified adapter pattern and include comprehensive test coverage.

## Key Modifications

### Configuration Updates
- **`internal/config/config.go`**: Added API key aliases 

### New Provider Implementations
- **`internal/llm/openai/`**: Complete OpenAI API integration
  - Includes structured output, and seed-based deterministic generation
  - Uses `max_completion_tokens` parameter for latest API compatibility

- **`internal/llm/anthropic/`**: Complete Anthropic Claude API integration
  - Handles system prompts, `/v1/messages`, and `x-api-key` auth as required by Anthropic's API

- **`internal/llm/groq/`**: Complete Groq API integration
  - Uses OpenAI-compatible API format
  - Includes frequency/presence penalty and seed support
 

### Registry Updates
- **`internal/registry/registry.go`** includes all three providers to the central registry