### PR TITLE
feat: JSONL

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,18 +202,19 @@ slop help [command-name]
 
 ### Output Formatting
 
+To receive a clean, structured response, simply add one of the following flags to your command. The tool will ensure properly formatted responses by guiding the model and cleaning the raw model output. 
+
 - `--json`: Format response as JSON
-  - **OpenAI/Mistral**: Uses provider-native JSON mode for guaranteed valid responses
-  - **Other providers**: Enhanced prompt-based formatting with automatic extraction
-- `--yaml`: Format response as YAML with intelligent prompt enhancement
-- `--md`: Format response as Markdown with intelligent prompt enhancement  
-- `--xml`: Format response as XML with intelligent prompt enhancement
+- `--jsonl`: Format response as newline-delimited JSONL
+- `--yaml`: Format response as YAML
+- `--md`: Format response as Markdown
+- `--xml`: Format response as XML
 
 Note: Format flags are mutually exclusive.
 
 ### Parameter Flags
 
-- `--temperature`: Sampling temperature (0.0-2.0)
+- `--temperature`: Sampling temperature
 - `--max-tokens`: Maximum response tokens
 - `--top-p`: Top-p sampling value
 - `--stop-sequences`: Stop sequences for generation

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,6 +25,8 @@ func enhanceSystemPromptForFormat(basePrompt string, format config.Format) strin
 	switch {
 	case format.JSON:
 		instruction = "You must format your entire response as a single, valid JSON object. Start your response with a single opening brace {"
+	case format.JSONL:
+		instruction = "You must format your response as newline-delimited JSON (JSONL). Each line must be a self-contained, valid JSON object. Do not use commas after each line; simply separate each JSON object with a newline."
 	case format.YAML:
 		instruction = "You must format your entire response as valid YAML. Do not include any text or formatting outside of the YAML structure."
 	case format.MD:

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -146,6 +146,7 @@ var rootCmd = &cobra.Command{
 			"deep":        "deep",
 			"temperature": "parameters.temperature",
 			"json":        "format.json",
+			"jsonl":       "format.jsonl",
 			"yaml":        "format.yaml",
 			"md":          "format.md",
 			"xml":         "format.xml",
@@ -228,6 +229,7 @@ func init() {
 
 	// Output formatting flags
 	rootCmd.PersistentFlags().Bool("json", false, "Format response as JSON")
+	rootCmd.PersistentFlags().Bool("jsonl", false, "Format response as JSONL (JSON Lines)")
 	rootCmd.PersistentFlags().Bool("yaml", false, "Format response as YAML")
 	rootCmd.PersistentFlags().Bool("md", false, "Format response as Markdown")
 	rootCmd.PersistentFlags().Bool("xml", false, "Format response as XML")
@@ -235,7 +237,7 @@ func init() {
 	// mark the mutually exclusive flags
 	rootCmd.MarkFlagsMutuallyExclusive("fast", "deep")
 	rootCmd.MarkFlagsMutuallyExclusive("local", "remote")
-	rootCmd.MarkFlagsMutuallyExclusive("json", "yaml", "md", "xml")
+	rootCmd.MarkFlagsMutuallyExclusive("json", "jsonl", "yaml", "md", "xml")
 
 	// list of flags to hide for now
 	flagsToHide := []string{"test", "stream"}

--- a/internal/config/data/default_config.toml
+++ b/internal/config/data/default_config.toml
@@ -53,6 +53,7 @@ max_retries = 2
 
 [format]
 json = false
+jsonl = false
 yaml = false
 md = false
 xml = false

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -217,6 +217,11 @@ func DefaultConfigSchema() *ConfigSchema {
 				Description: "Format response as JSON",
 				Default:     false,
 			},
+			"format.jsonl": {
+				Type:        reflect.TypeOf(bool(false)),
+				Description: "Format response as JSONL (newline-delimited JSON)",
+				Default:     false,
+			},
 			"format.yaml": {
 				Type:        reflect.TypeOf(bool(false)),
 				Description: "Format response as YAML",
@@ -270,6 +275,7 @@ func DefaultConfigSchema() *ConfigSchema {
 
 			// format aliases
 			"json":     "format.json",
+			"jsonl":    "format.jsonl",
 			"yaml":     "format.yaml",
 			"markdown": "format.md",
 			"md":       "format.md",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -31,10 +31,11 @@ type Parameters struct {
 
 // Format contains output formatting options
 type Format struct {
-	JSON bool `mapstructure:"json"`
-	YAML bool `mapstructure:"yaml"`
-	MD   bool `mapstructure:"md"`
-	XML  bool `mapstructure:"xml"`
+	JSON  bool `mapstructure:"json"`
+	JSONL bool `mapstructure:"jsonl"`
+	YAML  bool `mapstructure:"yaml"`
+	MD    bool `mapstructure:"md"`
+	XML   bool `mapstructure:"xml"`
 }
 
 // Models contains model configuration for different categories


### PR DESCRIPTION
This pull request introduces support for a new output format, JSONL (newline-delimited JSON), across the codebase. The changes include updates to the configuration, command-line flags, response cleaning logic, and associated documentation and tests.

### Implications
JSONL is an inherently _streamable_ format. This allows an initial inference to transform a high-level goal into a stream of structured, machine-readable sub-problems.

```bash
cat notice.txt \
  | ./slop --jsonl "Identify any violation of plain language principles and notate the line number, violation type ('Passive Voice', 'Jargon', 'Complex Sentence'), and the relevant text." \
  | parallel --bar ./slop "Suggest alternative plain language version of the text: {}" \
  | tee -a suggestions.txt \
  | ./slop --context notice.txt "Generate an improved notice." \
  >> new_notice.txt
```


### Key Modifications

- Configuration Updates
  - Added `jsonl` as a new format option in the configuration schema and default settings (`internal/config/schema.go`, `internal/config/data/default_config.toml`). [[1]](diffhunk://#diff-4fd940e67ba4534f34987a05fbd8441a28238c9c75262926abc9400a4b7346e2R220-R224) [[2]](diffhunk://#diff-fd128a6418655f174d76a7a7db287960b59ba93764d01bb33f33e7ed5d461addR56)
  - Updated the `Format` struct to include the `JSONL` field (`internal/config/types.go`).

- Command-Line Flags
  - Added support for the `--jsonl` flag in the CLI, including marking it as mutually exclusive with other format flags (`internal/cmd/root.go`). [[1]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dR149) [[2]](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dR232-R240)

- Response Cleaning Logic
  - Implemented the `CleanJSONL` function to extract and validate JSONL responses, including handling markdown fences and filtering invalid lines (`internal/format/cleaner.go`). [[1]](diffhunk://#diff-5447ded9aec6568fae2f4273473ed1a821ba835817f875d2869bfb3f88e296f1R17-R20) [[2]](diffhunk://#diff-5447ded9aec6568fae2f4273473ed1a821ba835817f875d2869bfb3f88e296f1R185-R237)

- Documentation Updates
  - Updated the `README.md` to include the `--jsonl` flag and its description in the output formatting section.