### PR TITLE
feat: persistent context

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ By integrating AI directly into your shell as a pipeline-native tool, you can bu
 - **Named commands**: Configure command shortcuts with your own custom system prompts
 - **Model selection**: Quickly switch between local or remote and fast or deep (reasoning) models
 - **Output formatting**: Specify JSON, Markdown, YAML, or XML for structured responses 
-- **Persistent project context**: Configure a directory with context files that are automatically embeded in every command
+- **Persistent project context**: Configure a directory with context files that are automatically embedded in every command
 - **Configuration management**: Define all settings in a TOML config file 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ By integrating AI directly into your shell as a pipeline-native tool, you can bu
 - **Named commands**: Configure command shortcuts with your own custom system prompts
 - **Model selection**: Quickly switch between local or remote and fast or deep (reasoning) models
 - **Output formatting**: Specify JSON, Markdown, YAML, or XML for structured responses 
+- **Persistent project context**: Configure a directory with context files that are automatically embeded in every command
 - **Configuration management**: Define all settings in a TOML config file 
 
 ## Installation
@@ -97,6 +98,50 @@ Use the `-l` or `--local` flag to run models privately on your machine via Ollam
 slop --local "Elaborate on the concept of a 'Ghost in the Machine' with a 2-page report"
 ```
 
+#### Supported Model Providers
+Slop supports multiple LLM providers:
+
+**Local Providers:**
+- **[Ollama](https://ollama.com/)** for open-weight models including Llama, Gemma, Deepseek, and many others
+
+**Remote Providers:**
+
+- **[Anthropic](https://www.anthropic.com/)**
+- **[Cohere](https://cohere.com/)**
+- **[Groq](https://groq.com/)**
+- **[Mistral AI](https://mistral.ai/)**
+- **[OpenAI](https://openai.com/)**
+
+### Persistent Context
+
+You can set up **persistent context** that automatically includes relevant files in every slop command run from a project directory. This eliminates the need to manually specify context files.
+
+```bash
+# Set up project context by adding files
+slop context add README.md
+
+# Future slop commands in this directory will includes the file(s) as context
+slop "Explain the main functionality of this project"
+```
+
+The context is managed through a `.slop/context` manifest file.
+
+```bash
+# View current project context
+slop context list
+
+# Add more files or directories
+slop context add src/utils/ tests/integration/
+
+# Clear all project context
+slop context clear
+
+# Skip project context for a single command
+slop --ignore-context "Quick question without project files"
+```
+
+**Tip**: Project context files are sent as individual messages to the LLM, providing better structure and understanding compared to concatenated text.
+
 ## Configuration
 
 Slop uses TOML configuration files located at `~/.slop/config.toml` by default.
@@ -158,8 +203,6 @@ model_hint = "reasoning"
 temperature = 0.3
 ```
 
-## Commands
-
 ### Configuration Management
 
 ```bash
@@ -193,12 +236,13 @@ slop help [command-name]
 - `--config`: Path to config file
 - `--system`: System prompt override
 - `--context`: Context file paths (can be used multiple times)
-- `--local`: Use local LLM provider
-- `--remote`: Use remote LLM provider  
-- `--fast`: Use fast/light model
-- `--deep`: Use deep/reasoning model
+- `--ignore-context`, `-i`: Ignore automated project context for this command
+- `--local`, `-l`: Use local LLM provider
+- `--remote`, `-r`: Use remote LLM provider  
+- `--fast`, `-f`: Use fast/light model
+- `--deep`, `d`: Use deep/reasoning model
 - `--test`: Use mock provider for testing
-- `--verbose, -v`: Enable structured logging
+- `--verbose`,  `-v`: Enable structured logging
 
 ### Output Formatting
 
@@ -214,7 +258,7 @@ Note: Format flags are mutually exclusive.
 
 ### Parameter Flags
 
-- `--temperature`: Sampling temperature
-- `--max-tokens`: Maximum response tokens
-- `--top-p`: Top-p sampling value
-- `--stop-sequences`: Stop sequences for generation
+- `--temperature`: Sampling randomness (higher for more creative output)
+- `--max-tokens`: Maximum response length in tokens
+- `--top-p`: Nucleus sampling threshold (affects variety)
+- `--stop-sequences`: Stop sequences, or strings that terminate generation

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -250,10 +250,10 @@ func (a *App) Run(ctx context.Context, cliArgs []string, contextResult *slopCont
 			case <-ctx.Done(): // handle context cancellation
 				return
 			case <-time.After(time.Duration(spinSpeed) * time.Millisecond):
-				baseMessage := fmt.Sprintf("%s %s", spinGlyphs[i], modelName) //always display model name and glyph
+				baseMessage := fmt.Sprintf("%s %s", spinGlyphs[i], modelName) // always display model name and glyph
 				switch projectContextCount {
 				case 0:
-					baseMessage += " is generating..." //default
+					baseMessage += " is generating..." // default
 				case 1:
 					if len(contextFiles) > 0 {
 						fileName := filepath.Base(contextFiles[0].Path)

--- a/internal/cmd/context_commands.go
+++ b/internal/cmd/context_commands.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"slop/internal/manifest"
+
+	"github.com/spf13/cobra"
+)
+
+// createContextCommand creates the context management command with subcommands
+func createContextCommand() *cobra.Command {
+	contextCmd := &cobra.Command{
+		Use:   "context",
+		Short: "Manage persistent context for the current directory",
+		Long:  "Manage persistent file context using .slop/context manifest files. Searches for manifest in current directory and parent directories.",
+	}
+
+	// add subcommands
+	contextCmd.AddCommand(createContextAddCommand())
+	contextCmd.AddCommand(createContextListCommand())
+	contextCmd.AddCommand(createContextClearCommand())
+
+	return contextCmd
+}
+
+// createContextAddCommand creates the 'context add' subcommand
+func createContextAddCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add <path...>",
+		Short: "Add files to the current directory context",
+		Long:  `Add one or more files to the current directory context. Creates context manifest for the current directory if no manifest is found.`,
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manager := manifest.NewManifestManager("")
+			manifestPath := manager.GetManifestPath()
+
+			// expand and validate paths
+			var validPaths []string
+			for _, arg := range args {
+				// convert to absolute path for validation
+				absPath, err := filepath.Abs(arg)
+				if err != nil {
+					return fmt.Errorf("invalid path %q: %w", arg, err)
+				}
+
+				// check if path exists
+				if _, err := os.Stat(absPath); err != nil {
+					return fmt.Errorf("path does not exist: %q", arg)
+				}
+
+				// store the original argument (which may be relative)
+				validPaths = append(validPaths, arg)
+			}
+
+			// add paths to manifest
+			err := manager.AddPaths(manifestPath, validPaths)
+			if err != nil {
+				return fmt.Errorf("failed to add paths to context: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Added %d path(s) to project context:\n", len(validPaths))
+			for _, path := range validPaths {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", path)
+			}
+
+			return nil
+		},
+	}
+}
+
+// createContextListCommand creates the 'context list' subcommand
+func createContextListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all files in the current directory's context",
+		Long:  "Display all files in the context manifest found in current directory.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manager := manifest.NewManifestManager("")
+
+			manifestPath, projectRoot, err := manager.FindManifest()
+			if err != nil {
+				return fmt.Errorf("failed to find manifest: %w", err)
+			}
+
+			if manifestPath == "" {
+				fmt.Fprintln(cmd.OutOrStdout(), "No context manifest found. Use 'slop context add' to create one in current directory.")
+				return nil
+			}
+
+			paths, err := manager.LoadManifest(manifestPath)
+			if err != nil {
+				return fmt.Errorf("failed to load manifest: %w", err)
+			}
+
+			if len(paths) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Context manifest is empty. Use 'slop context add' to add files.")
+				return nil
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Context files (from %s):\n", projectRoot)
+			for i, path := range paths {
+				fmt.Fprintf(cmd.OutOrStdout(), "%3d. %s\n", i+1, path)
+			}
+
+			return nil
+		},
+	}
+}
+
+// createContextClearCommand creates the 'context clear' subcommand
+func createContextClearCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "Remove all files from the current directory's context",
+		Long:  "Clear all files from the context manifest found in current directory.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manager := manifest.NewManifestManager("")
+
+			manifestPath, projectRoot, err := manager.FindManifest()
+			if err != nil {
+				return fmt.Errorf("failed to find manifest: %w", err)
+			}
+
+			if manifestPath == "" {
+				fmt.Fprintln(cmd.OutOrStdout(), "No context manifest found.")
+				return nil
+			}
+
+			// load existing paths to show what's being cleared
+			paths, err := manager.LoadManifest(manifestPath)
+			if err != nil {
+				return fmt.Errorf("failed to load manifest: %w", err)
+			}
+
+			if len(paths) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Context manifest is already empty.")
+				return nil
+			}
+
+			// clear the manifest
+			err = manager.ClearManifest(manifestPath)
+			if err != nil {
+				return fmt.Errorf("failed to clear context: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Cleared %d path(s) from context manifest in %s\n", len(paths), projectRoot)
+
+			return nil
+		},
+	}
+}

--- a/internal/cmd/context_test.go
+++ b/internal/cmd/context_test.go
@@ -164,10 +164,8 @@ func TestProcessContext_ErrorCases(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errorText) {
 					t.Errorf("Expected error containing %q, got: %v", tt.errorText, err)
 				}
-			} else {
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
 			}
 		})
 	}

--- a/internal/cmd/context_test.go
+++ b/internal/cmd/context_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	slopContext "slop/internal/context"
 
 	"github.com/spf13/cobra"
 )
@@ -19,8 +23,24 @@ func TestNewContextManager(t *testing.T) {
 	var _ ContextManager = manager
 }
 
-// TestProcessContext tests nearly all context processing scenarios
+// TestProcessContext tests context processing scenarios
 func TestProcessContext(t *testing.T) {
+	// Create temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "slop-context-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create minimal test files
+	testFiles := []string{"windmill.txt", "snowball.txt", "file1.txt"}
+	for _, filename := range testFiles {
+		filePath := filepath.Join(tempDir, filename)
+		if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+			t.Fatalf("Failed to create test file %s: %v", filename, err)
+		}
+	}
+
 	tests := []struct {
 		name            string
 		cliContextFiles []string
@@ -28,7 +48,6 @@ func TestProcessContext(t *testing.T) {
 		expectedAll     []string
 		expectedCLI     []string
 		expectedCmd     []string
-		shouldError     bool
 	}{
 		{
 			name:            "empty everything",
@@ -39,28 +58,20 @@ func TestProcessContext(t *testing.T) {
 			expectedCmd:     []string{},
 		},
 		{
-			name:            "Files",
-			cliContextFiles: []string{"windmill.txt", "snowball.txt"},
+			name:            "cli files only",
+			cliContextFiles: []string{filepath.Join(tempDir, "windmill.txt"), filepath.Join(tempDir, "snowball.txt")},
 			additionalFiles: []string{},
-			expectedAll:     []string{"windmill.txt", "snowball.txt"},
-			expectedCLI:     []string{"windmill.txt", "snowball.txt"},
+			expectedAll:     []string{filepath.Join(tempDir, "windmill.txt"), filepath.Join(tempDir, "snowball.txt")},
+			expectedCLI:     []string{filepath.Join(tempDir, "windmill.txt"), filepath.Join(tempDir, "snowball.txt")},
 			expectedCmd:     []string{},
 		},
 		{
-			name:            "duplicate file names allowed",
-			cliContextFiles: []string{"file1.txt"},
-			additionalFiles: []string{"file1.txt"},
-			expectedAll:     []string{"file1.txt", "file1.txt"},
-			expectedCLI:     []string{"file1.txt"},
-			expectedCmd:     []string{"file1.txt"},
-		},
-		{
-			name:            "files with special characters",
-			cliContextFiles: []string{"file with spaces.txt", "file-with-dashes.txt"},
-			additionalFiles: []string{"file_with_underscores.txt"},
-			expectedAll:     []string{"file with spaces.txt", "file-with-dashes.txt", "file_with_underscores.txt"},
-			expectedCLI:     []string{"file with spaces.txt", "file-with-dashes.txt"},
-			expectedCmd:     []string{"file_with_underscores.txt"},
+			name:            "duplicate files allowed",
+			cliContextFiles: []string{filepath.Join(tempDir, "file1.txt")},
+			additionalFiles: []string{filepath.Join(tempDir, "file1.txt")},
+			expectedAll:     []string{filepath.Join(tempDir, "file1.txt"), filepath.Join(tempDir, "file1.txt")},
+			expectedCLI:     []string{filepath.Join(tempDir, "file1.txt")},
+			expectedCmd:     []string{filepath.Join(tempDir, "file1.txt")},
 		},
 	}
 
@@ -79,14 +90,8 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			manager := NewContextManager()
-			result, err := manager.ProcessContext(cmd, tt.additionalFiles)
-
-			if tt.shouldError {
-				if err == nil {
-					t.Fatal("Expected error but got none")
-				}
-				return
-			}
+			// Use ProcessContextWithFlags with skipProjectContext=true to avoid file reading in tests
+			result, err := manager.ProcessContextWithFlags(cmd, tt.additionalFiles, true)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -106,37 +111,66 @@ func TestProcessContext(t *testing.T) {
 	}
 }
 
-// TestProcessContext_FlagError tests error handling when flag doesn't exist
-func TestProcessContext_FlagError(t *testing.T) {
-	// create command without context flag
-	cmd := &cobra.Command{Use: "test"}
-
-	manager := NewContextManager()
-	result, err := manager.ProcessContext(cmd, []string{"file.txt"})
-
-	if err == nil {
-		t.Fatal("Expected error when context flag is not defined")
+// TestProcessContext_ErrorCases tests error handling scenarios
+func TestProcessContext_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupCmd    func() *cobra.Command
+		expectPanic bool
+		expectError bool
+		errorText   string
+	}{
+		{
+			name: "missing context flag",
+			setupCmd: func() *cobra.Command {
+				return &cobra.Command{Use: "test"} // no context flag defined
+			},
+			expectError: true,
+			errorText:   "failed to get context flag",
+		},
+		{
+			name: "nil command",
+			setupCmd: func() *cobra.Command {
+				return nil
+			},
+			expectPanic: true,
+		},
 	}
-	if result != nil {
-		t.Errorf("Expected nil result when error occurs, got %v", result)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewContextManager()
+
+			if tt.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Fatal("Expected panic but function returned normally")
+					}
+				}()
+				_, _ = manager.ProcessContext(tt.setupCmd(), []string{"file.txt"})
+				t.Fatal("Expected panic but function returned normally")
+				return
+			}
+
+			result, err := manager.ProcessContext(tt.setupCmd(), []string{"file.txt"})
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				if result != nil {
+					t.Errorf("Expected nil result when error occurs, got %v", result)
+				}
+				if !strings.Contains(err.Error(), tt.errorText) {
+					t.Errorf("Expected error containing %q, got: %v", tt.errorText, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+			}
+		})
 	}
-	if !strings.Contains(err.Error(), "failed to get context flag") {
-		t.Errorf("Expected error about flag, got: %v", err)
-	}
-}
-
-// TestProcessContext_NilCommand tests panic handling with nil command
-func TestProcessContext_NilCommand(t *testing.T) {
-	manager := NewContextManager()
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("Expected panic when passing nil command")
-		}
-	}()
-
-	_, _ = manager.ProcessContext(nil, []string{"file.txt"})
-	t.Fatal("Expected panic but function returned normally")
 }
 
 // TestContextResult_HelperMethods tests all Has* methods
@@ -190,7 +224,7 @@ func TestContextResult_HelperMethods(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := &ContextResult{
+			result := &slopContext.ContextResult{
 				AllContextFiles: tt.allFiles,
 				CLIContextFiles: tt.cliFiles,
 				CmdContextFiles: tt.cmdFiles,

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -1,0 +1,36 @@
+package context
+
+// ContextFile represents a single context file with its path and content
+type ContextFile struct {
+	Path    string
+	Content string
+}
+
+// ContextResult contains the result of context processing
+type ContextResult struct {
+	AllContextFiles []string
+	CLIContextFiles []string
+	CmdContextFiles []string
+	// Structured context data for synthetic message history
+	ContextFileContents []ContextFile
+}
+
+// HasContextFiles returns true if any context files are present
+func (c *ContextResult) HasContextFiles() bool {
+	return len(c.AllContextFiles) > 0
+}
+
+// HasCLIContextFiles returns true if context files were provided via CLI flag
+func (c *ContextResult) HasCLIContextFiles() bool {
+	return len(c.CLIContextFiles) > 0
+}
+
+// HasCommandContextFiles returns true if context files were provided by the command
+func (c *ContextResult) HasCommandContextFiles() bool {
+	return len(c.CmdContextFiles) > 0
+}
+
+// HasStructuredContent returns true if structured context content is available
+func (c *ContextResult) HasStructuredContent() bool {
+	return len(c.ContextFileContents) > 0
+}

--- a/internal/io/input_test.go
+++ b/internal/io/input_test.go
@@ -2,166 +2,119 @@ package io
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
+
+	slopContext "slop/internal/context"
 )
 
-func TestReadInput(t *testing.T) {
+func TestReadInput_StructuredProcessing(t *testing.T) {
 	tests := []struct {
-		name           string
-		stdinContent   string
-		cliArgs        []string
-		contextFiles   []string
-		fileContents   map[string]string // filename -> content
-		expectedOutput string
-		expectError    bool
-		errorContains  string
+		name              string
+		stdinContent      string
+		cliArgs           []string
+		contextFiles      []slopContext.ContextFile
+		commandContext    string
+		expectedStdin     string
+		expectedCLI       string
+		expectedCommand   string
+		expectedFileCount int
+		expectError       bool
+		errorContains     string
 	}{
 		{
-			name:           "CLI args only",
-			stdinContent:   "",
-			cliArgs:        []string{"hello", "world"},
-			contextFiles:   []string{},
-			fileContents:   map[string]string{},
-			expectedOutput: "hello world",
-			expectError:    false,
+			name:              "CLI args only",
+			stdinContent:      "",
+			cliArgs:           []string{"hello", "world"},
+			contextFiles:      []slopContext.ContextFile{},
+			commandContext:    "",
+			expectedStdin:     "",
+			expectedCLI:       "hello world",
+			expectedCommand:   "",
+			expectedFileCount: 0,
+			expectError:       false,
 		},
 		{
-			name:           "Empty CLI args",
-			stdinContent:   "",
-			cliArgs:        []string{},
-			contextFiles:   []string{},
-			fileContents:   map[string]string{},
-			expectedOutput: "",
-			expectError:    false,
+			name:              "Empty CLI args",
+			stdinContent:      "",
+			cliArgs:           []string{},
+			contextFiles:      []slopContext.ContextFile{},
+			commandContext:    "",
+			expectedStdin:     "",
+			expectedCLI:       "",
+			expectedCommand:   "",
+			expectedFileCount: 0,
+			expectError:       false,
 		},
 		{
-			name:           "Stdin only",
-			stdinContent:   "This is from stdin",
-			cliArgs:        []string{},
-			contextFiles:   []string{},
-			fileContents:   map[string]string{},
-			expectedOutput: "This is from stdin",
-			expectError:    false,
+			name:              "Stdin only",
+			stdinContent:      "This is from stdin",
+			cliArgs:           []string{},
+			contextFiles:      []slopContext.ContextFile{},
+			commandContext:    "",
+			expectedStdin:     "This is from stdin",
+			expectedCLI:       "",
+			expectedCommand:   "",
+			expectedFileCount: 0,
+			expectError:       false,
 		},
 		{
-			name:           "Context file only",
-			stdinContent:   "",
-			cliArgs:        []string{},
-			contextFiles:   []string{"file1.txt"},
-			fileContents:   map[string]string{"file1.txt": "Content from file 1"},
-			expectedOutput: "Content from file 1",
-			expectError:    false,
+			name:         "Context files",
+			stdinContent: "",
+			cliArgs:      []string{},
+			contextFiles: []slopContext.ContextFile{
+				{Path: "file1.txt", Content: "Content from file 1"},
+				{Path: "file2.txt", Content: "Content from file 2"},
+			},
+			commandContext:    "",
+			expectedStdin:     "",
+			expectedCLI:       "",
+			expectedCommand:   "",
+			expectedFileCount: 2,
+			expectError:       false,
 		},
 		{
-			name:           "Multiple context files",
-			stdinContent:   "",
-			cliArgs:        []string{},
-			contextFiles:   []string{"file1.txt", "file2.txt"},
-			fileContents:   map[string]string{"file1.txt": "Content from file 1", "file2.txt": "Content from file 2"},
-			expectedOutput: "Content from file 1\n\nContent from file 2",
-			expectError:    false,
+			name:              "Command context only",
+			stdinContent:      "",
+			cliArgs:           []string{},
+			contextFiles:      []slopContext.ContextFile{},
+			commandContext:    "This is command context",
+			expectedStdin:     "",
+			expectedCLI:       "",
+			expectedCommand:   "This is command context",
+			expectedFileCount: 0,
+			expectError:       false,
 		},
 		{
-			name:           "All sources combined",
-			stdinContent:   "Stdin content",
-			cliArgs:        []string{"cli", "args"},
-			contextFiles:   []string{"file1.txt"},
-			fileContents:   map[string]string{"file1.txt": "File content"},
-			expectedOutput: "Stdin content\n\nFile content\n\ncli args",
-			expectError:    false,
+			name:         "All sources combined",
+			stdinContent: "Stdin content",
+			cliArgs:      []string{"cli", "args"},
+			contextFiles: []slopContext.ContextFile{
+				{Path: "file1.txt", Content: "File content"},
+			},
+			commandContext:    "Command context",
+			expectedStdin:     "Stdin content",
+			expectedCLI:       "cli args",
+			expectedCommand:   "Command context",
+			expectedFileCount: 1,
+			expectError:       false,
 		},
 		{
-			name:           "Stdin with trailing whitespace",
-			stdinContent:   "Stdin content\n\n\t  ",
-			cliArgs:        []string{},
-			contextFiles:   []string{},
-			fileContents:   map[string]string{},
-			expectedOutput: "Stdin content",
-			expectError:    false,
-		},
-		{
-			name:           "File with trailing whitespace",
-			stdinContent:   "",
-			cliArgs:        []string{},
-			contextFiles:   []string{"file1.txt"},
-			fileContents:   map[string]string{"file1.txt": "File content\n\r\n\t  "},
-			expectedOutput: "File content",
-			expectError:    false,
-		},
-		{
-			name:           "Empty context files are ignored",
-			stdinContent:   "",
-			cliArgs:        []string{"args"},
-			contextFiles:   []string{"", "file1.txt", ""},
-			fileContents:   map[string]string{"file1.txt": "File content"},
-			expectedOutput: "File content\n\nargs",
-			expectError:    false,
-		},
-		{
-			name:           "Empty file content",
-			stdinContent:   "",
-			cliArgs:        []string{"args"},
-			contextFiles:   []string{"empty.txt"},
-			fileContents:   map[string]string{"empty.txt": ""},
-			expectedOutput: "args",
-			expectError:    false,
-		},
-		{
-			name:           "File content with only whitespace",
-			stdinContent:   "",
-			cliArgs:        []string{"args"},
-			contextFiles:   []string{"whitespace.txt"},
-			fileContents:   map[string]string{"whitespace.txt": "\n\t  \r\n"},
-			expectedOutput: "args",
-			expectError:    false,
-		},
-		{
-			name:           "Nonexistent context file",
-			stdinContent:   "",
-			cliArgs:        []string{},
-			contextFiles:   []string{"nonexistent.txt"},
-			fileContents:   map[string]string{},
-			expectedOutput: "",
-			expectError:    true,
-			errorContains:  "failed to read context file",
-		},
-		{
-			name:           "Multiline content preservation",
-			stdinContent:   "Line 1\nLine 2\nLine 3",
-			cliArgs:        []string{"final", "args"},
-			contextFiles:   []string{"multiline.txt"},
-			fileContents:   map[string]string{"multiline.txt": "File line 1\nFile line 2"},
-			expectedOutput: "Line 1\nLine 2\nLine 3\n\nFile line 1\nFile line 2\n\nfinal args",
-			expectError:    false,
+			name:              "Stdin with trailing whitespace",
+			stdinContent:      "Stdin content\n\n\t  ",
+			cliArgs:           []string{},
+			contextFiles:      []slopContext.ContextFile{},
+			commandContext:    "",
+			expectedStdin:     "Stdin content",
+			expectedCLI:       "",
+			expectedCommand:   "",
+			expectedFileCount: 0,
+			expectError:       false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// create temp directory for test files
-			tempDir := t.TempDir()
-
-			// create context files in temp directory
-			var contextFilePaths []string
-			for _, fileName := range tt.contextFiles {
-				if fileName == "" {
-					contextFilePaths = append(contextFilePaths, "")
-					continue
-				}
-
-				filePath := filepath.Join(tempDir, fileName)
-				content, exists := tt.fileContents[fileName]
-				if exists {
-					err := os.WriteFile(filePath, []byte(content), 0644)
-					if err != nil {
-						t.Fatalf("Failed to create test file %s: %v", filePath, err)
-					}
-				}
-				contextFilePaths = append(contextFilePaths, filePath)
-			}
-
 			// create stdin pipe if needed
 			var stdin *os.File
 			if tt.stdinContent != "" {
@@ -182,7 +135,7 @@ func TestReadInput(t *testing.T) {
 			}
 
 			// execute the function
-			result, err := ReadInput(stdin, tt.cliArgs, contextFilePaths)
+			result, err := ReadInput(stdin, tt.cliArgs, tt.contextFiles, tt.commandContext)
 
 			// check error expectation
 			if tt.expectError {
@@ -199,9 +152,32 @@ func TestReadInput(t *testing.T) {
 				return
 			}
 
-			// check output
-			if result != tt.expectedOutput {
-				t.Errorf("Expected output:\n%q\nGot:\n%q", tt.expectedOutput, result)
+			// check structured output
+			if result.CommandContext != tt.expectedCommand {
+				t.Errorf("Expected command context:\n%q\nGot:\n%q", tt.expectedCommand, result.CommandContext)
+			}
+			if result.StdinContent != tt.expectedStdin {
+				t.Errorf("Expected stdin content:\n%q\nGot:\n%q", tt.expectedStdin, result.StdinContent)
+			}
+			if result.CLIArgs != tt.expectedCLI {
+				t.Errorf("Expected CLI args:\n%q\nGot:\n%q", tt.expectedCLI, result.CLIArgs)
+			}
+			if len(result.ContextFiles) != tt.expectedFileCount {
+				t.Errorf("Expected %d context files, got %d", tt.expectedFileCount, len(result.ContextFiles))
+			}
+
+			// verify context file content matches
+			for i, expectedFile := range tt.contextFiles {
+				if i >= len(result.ContextFiles) {
+					t.Errorf("Missing expected context file %d", i)
+					continue
+				}
+				if result.ContextFiles[i].Path != expectedFile.Path {
+					t.Errorf("Expected context file path %q, got %q", expectedFile.Path, result.ContextFiles[i].Path)
+				}
+				if result.ContextFiles[i].Content != expectedFile.Content {
+					t.Errorf("Expected context file content %q, got %q", expectedFile.Content, result.ContextFiles[i].Content)
+				}
 			}
 		})
 	}
@@ -209,14 +185,17 @@ func TestReadInput(t *testing.T) {
 
 func TestReadInput_NilStdin(t *testing.T) {
 	// test with nil stdin (should not crash)
-	result, err := ReadInput(nil, []string{"test", "args"}, []string{})
+	result, err := ReadInput(nil, []string{"test", "args"}, []slopContext.ContextFile{}, "")
 	if err != nil {
 		t.Errorf("Expected no error with nil stdin, got: %v", err)
 	}
 
 	expected := "test args"
-	if result != expected {
-		t.Errorf("Expected %q, got %q", expected, result)
+	if result.CLIArgs != expected {
+		t.Errorf("Expected CLI args %q, got %q", expected, result.CLIArgs)
+	}
+	if result.StdinContent != "" {
+		t.Errorf("Expected empty stdin content, got %q", result.StdinContent)
 	}
 }
 
@@ -230,13 +209,16 @@ func TestReadInput_StdinWithoutData(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 	defer tempFile.Close()
 
-	result, err := ReadInput(tempFile, []string{"test", "args"}, []string{})
+	result, err := ReadInput(tempFile, []string{"test", "args"}, []slopContext.ContextFile{}, "")
 	if err != nil {
 		t.Errorf("Expected no error with empty stdin file, got: %v", err)
 	}
 
 	expected := "test args"
-	if result != expected {
-		t.Errorf("Expected %q, got %q", expected, result)
+	if result.CLIArgs != expected {
+		t.Errorf("Expected CLI args %q, got %q", expected, result.CLIArgs)
+	}
+	if result.StdinContent != "" {
+		t.Errorf("Expected empty stdin content, got %q", result.StdinContent)
 	}
 }

--- a/internal/manifest/manager.go
+++ b/internal/manifest/manager.go
@@ -1,0 +1,214 @@
+package manifest
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	slopContext "slop/internal/context"
+)
+
+// ManifestManager handles .slop/context manifest for persistent project context
+type ManifestManager struct {
+	workingDir string
+}
+
+// NewManifestManager creates new manifest manager for given working directory
+func NewManifestManager(workingDir string) *ManifestManager {
+	if workingDir == "" {
+		workingDir, _ = os.Getwd()
+	}
+	return &ManifestManager{
+		workingDir: workingDir,
+	}
+}
+
+// FindManifest searches for a .slop/context manifest file in the current directory
+// returns the path to the manifest file and the dir, or empty strings if not found
+func (m *ManifestManager) FindManifest() (string, string, error) {
+	// check if .slop/context exists in current directoryy
+	manifestPath := filepath.Join(m.workingDir, ".slop", "context")
+	if _, err := os.Stat(manifestPath); err == nil {
+		return manifestPath, m.workingDir, nil
+	}
+
+	// possible future enhancement: traverse the directory tree
+	/*
+		currentDir := m.workingDir
+
+		for {
+			// check if .slop/context exists in current directory
+			manifestPath := filepath.Join(currentDir, ".slop", "context")
+			if _, err := os.Stat(manifestPath); err == nil {
+				return manifestPath, currentDir, nil
+			}
+
+			// move up one level
+			parent := filepath.Dir(currentDir)
+			if parent == currentDir {
+				// reached root directory
+				break
+			}
+			currentDir = parent
+		}
+	*/
+
+	return "", "", nil // not found
+}
+
+// LoadManifest reads and parses a manifest file
+func (m *ManifestManager) LoadManifest(manifestPath string) ([]string, error) {
+	file, err := os.Open(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open manifest file: %w", err)
+	}
+	defer file.Close()
+
+	var paths []string
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// skip empty lines, allow # comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		paths = append(paths, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read manifest file: %w", err)
+	}
+
+	return paths, nil
+}
+
+// SaveManifest writes to manifest file
+func (m *ManifestManager) SaveManifest(manifestPath string, paths []string) error {
+	// ensure .slop directory exists
+	dir := filepath.Dir(manifestPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create .slop directory: %w", err)
+	}
+
+	file, err := os.Create(manifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to create manifest file: %w", err)
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+
+	// write header comment
+	if _, err := writer.WriteString("# slop context manifest\n"); err != nil {
+		return fmt.Errorf("failed to write manifest header: %w", err)
+	}
+	if _, err := writer.WriteString("# This file contains paths to context files for this project\n\n"); err != nil {
+		return fmt.Errorf("failed to write manifest header: %w", err)
+	}
+
+	// write paths
+	for _, path := range paths {
+		if _, err := writer.WriteString(path + "\n"); err != nil {
+			return fmt.Errorf("failed to write path to manifest: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// AddPaths adds new paths to the manifest file
+func (m *ManifestManager) AddPaths(manifestPath string, newPaths []string) error {
+	// load existing paths
+	var existingPaths []string
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		// manifest doesn't exist yet, start with empty list
+		existingPaths = []string{}
+	} else {
+		// manifest exists, load it
+		var err error
+		existingPaths, err = m.LoadManifest(manifestPath)
+		if err != nil {
+			return fmt.Errorf("failed to load existing manifest: %w", err)
+		}
+	}
+
+	// merge paths, avoiding duplicates
+	pathSet := make(map[string]bool)
+	for _, path := range existingPaths {
+		pathSet[path] = true
+	}
+
+	var allPaths []string
+	allPaths = append(allPaths, existingPaths...)
+
+	for _, newPath := range newPaths {
+		if !pathSet[newPath] {
+			allPaths = append(allPaths, newPath)
+			pathSet[newPath] = true
+		}
+	}
+
+	return m.SaveManifest(manifestPath, allPaths)
+}
+
+// ClearManifest removes all paths from the manifest file
+func (m *ManifestManager) ClearManifest(manifestPath string) error {
+	return m.SaveManifest(manifestPath, []string{})
+}
+
+// LoadProjectContext discovers and loads context files from the manifest
+func (m *ManifestManager) LoadProjectContext() ([]slopContext.ContextFile, error) {
+	manifestPath, projectRoot, err := m.FindManifest()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find manifest: %w", err)
+	}
+
+	if manifestPath == "" {
+		// no manifest found
+		return []slopContext.ContextFile{}, nil
+	}
+
+	paths, err := m.LoadManifest(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load manifest: %w", err)
+	}
+
+	var contextFiles []slopContext.ContextFile
+
+	for _, path := range paths {
+		// resolve relative paths against project root
+		var fullPath string
+		if filepath.IsAbs(path) {
+			fullPath = path
+		} else {
+			fullPath = filepath.Join(projectRoot, path)
+		}
+
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			// print warning to stderr, let user know
+			fmt.Fprintf(os.Stderr, "Warning: could not read context file %s: %v\n", fullPath, err)
+			continue
+		}
+
+		// trim trailing whitespace
+		fileContent := strings.TrimRight(string(content), "\r\n\t ")
+		if fileContent != "" {
+			contextFiles = append(contextFiles, slopContext.ContextFile{
+				Path:    fullPath,
+				Content: fileContent,
+			})
+		}
+	}
+
+	return contextFiles, nil
+}
+
+// GetManifestPath returns the path where a manifest would be created
+func (m *ManifestManager) GetManifestPath() string {
+	return filepath.Join(m.workingDir, ".slop", "context")
+}

--- a/internal/manifest/manager_test.go
+++ b/internal/manifest/manager_test.go
@@ -1,0 +1,513 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	slopContext "slop/internal/context"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createManifestFile is a helper function to create a manifest file w/ content
+func createManifestFile(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	slopDir := filepath.Join(dir, ".slop")
+	err := os.MkdirAll(slopDir, 0700)
+	require.NoError(t, err)
+
+	manifestPath := filepath.Join(slopDir, "context")
+	err = os.WriteFile(manifestPath, []byte(content), 0644)
+	require.NoError(t, err)
+
+	return manifestPath
+}
+
+// createTestFile is a helper function to create a test file w/ content
+func createTestFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	dir := filepath.Dir(path)
+	err := os.MkdirAll(dir, 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(path, []byte(content), 0644)
+	require.NoError(t, err)
+}
+
+func TestNewManifestManager(t *testing.T) {
+	tests := []struct {
+		name           string
+		workingDir     string
+		expectedResult func(string) string
+	}{
+		{
+			name:       "with non-empty working directory",
+			workingDir: "/test/path",
+			expectedResult: func(string) string {
+				return "/test/path"
+			},
+		},
+		{
+			name:       "with empty working directory",
+			workingDir: "",
+			expectedResult: func(string) string {
+				wd, _ := os.Getwd()
+				return wd
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManifestManager(tt.workingDir)
+
+			assert.NotNil(t, manager)
+			assert.Equal(t, tt.expectedResult(tt.workingDir), manager.workingDir)
+		})
+	}
+}
+
+func TestManifestManager_FindManifest(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupFunc     func(t *testing.T) string
+		expectedFound bool
+		expectError   bool
+	}{
+		{
+			name: "manifest exists in current directory",
+			setupFunc: func(t *testing.T) string {
+				tempDir := t.TempDir()
+				createManifestFile(t, tempDir, "file1.txt\nfile2.txt")
+				return tempDir
+			},
+			expectedFound: true,
+			expectError:   false,
+		},
+		{
+			name: "manifest does not exist",
+			setupFunc: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			expectedFound: false,
+			expectError:   false,
+		},
+		{
+			name: "working directory does not exist",
+			setupFunc: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "nonexistent")
+			},
+			expectedFound: false,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workingDir := tt.setupFunc(t)
+			manager := NewManifestManager(workingDir)
+
+			manifestPath, foundDir, err := manager.FindManifest()
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.expectedFound {
+				assert.NotEmpty(t, manifestPath)
+				assert.Equal(t, workingDir, foundDir)
+			} else {
+				assert.Empty(t, manifestPath)
+				assert.Empty(t, foundDir)
+			}
+		})
+	}
+}
+
+func TestManifestManager_LoadManifest(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		expectedPaths []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "simple paths",
+			content:       "file1.txt\nfile2.txt\npath/to/file3.txt",
+			expectedPaths: []string{"file1.txt", "file2.txt", "path/to/file3.txt"},
+		},
+		{
+			name:          "paths with comments and empty lines",
+			content:       "# This is a comment\nfile1.txt\n\n# Another comment\nfile2.txt\n\n# Empty line above and below\n\npath/to/file3.txt\n# Final comment",
+			expectedPaths: []string{"file1.txt", "file2.txt", "path/to/file3.txt"},
+		},
+		{
+			name:          "paths with whitespace",
+			content:       "  file1.txt  \n\t file2.txt \t\n   path/to/file3.txt   ",
+			expectedPaths: []string{"file1.txt", "file2.txt", "path/to/file3.txt"},
+		},
+		{
+			name:          "empty file",
+			content:       "",
+			expectedPaths: nil,
+		},
+		{
+			name:          "only comments and whitespace",
+			content:       "# comment1\n\n# comment2\n   \n\t\n   ",
+			expectedPaths: nil,
+		},
+		{
+			name:          "file not found",
+			content:       "nonexistent",
+			expectError:   true,
+			errorContains: "failed to open manifest file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			var manifestPath string
+
+			if tt.name == "file not found" {
+				manifestPath = filepath.Join(tempDir, "nonexistent.txt")
+			} else {
+				manifestPath = createManifestFile(t, tempDir, tt.content)
+			}
+
+			manager := NewManifestManager(tempDir)
+			paths, err := manager.LoadManifest(manifestPath)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, paths)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedPaths, paths)
+			}
+		})
+	}
+}
+
+func TestManifestManager_SaveManifest(t *testing.T) {
+	tests := []struct {
+		name             string
+		paths            []string
+		createDir        bool
+		verifyDirCreated bool
+	}{
+		{
+			name:             "save with basic paths",
+			paths:            []string{"muriel.txt", "boxer.txt", "path/to/raven.txt"},
+			createDir:        false,
+			verifyDirCreated: true,
+		},
+		{
+			name:             "save empty paths list",
+			paths:            []string{},
+			createDir:        false,
+			verifyDirCreated: true,
+		},
+		{
+			name:      "save to existing directory",
+			paths:     []string{"existing.txt"},
+			createDir: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			manifestPath := filepath.Join(tempDir, ".slop", "context")
+
+			if tt.createDir {
+				err := os.MkdirAll(filepath.Dir(manifestPath), 0700)
+				require.NoError(t, err)
+			}
+
+			manager := NewManifestManager("")
+			err := manager.SaveManifest(manifestPath, tt.paths)
+
+			assert.NoError(t, err)
+			assert.FileExists(t, manifestPath)
+
+			if tt.verifyDirCreated {
+				assert.DirExists(t, filepath.Dir(manifestPath))
+			}
+
+			// verify content
+			content, err := os.ReadFile(manifestPath)
+			assert.NoError(t, err)
+
+			lines := strings.Split(string(content), "\n")
+			assert.Contains(t, lines[0], "# slop context manifest")
+			assert.Contains(t, lines[1], "# This file contains paths")
+
+			contentStr := string(content)
+			for _, path := range tt.paths {
+				assert.Contains(t, contentStr, path)
+			}
+		})
+	}
+}
+
+func TestManifestManager_AddPaths(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingContent string
+		newPaths        []string
+		expectedPaths   []string
+	}{
+		{
+			name:            "add to new manifest",
+			existingContent: "",
+			newPaths:        []string{"file1.txt", "file2.txt"},
+			expectedPaths:   []string{"file1.txt", "file2.txt"},
+		},
+		{
+			name:            "add to existing manifest",
+			existingContent: "existing1.txt\nexisting2.txt",
+			newPaths:        []string{"new1.txt", "new2.txt"},
+			expectedPaths:   []string{"existing1.txt", "existing2.txt", "new1.txt", "new2.txt"},
+		},
+		{
+			name:            "add with duplicates (deduplication)",
+			existingContent: "file1.txt\nfile2.txt",
+			newPaths:        []string{"file1.txt", "file3.txt", "file2.txt", "file4.txt"},
+			expectedPaths:   []string{"file1.txt", "file2.txt", "file3.txt", "file4.txt"},
+		},
+		{
+			name:            "add all duplicates",
+			existingContent: "file1.txt\nfile2.txt",
+			newPaths:        []string{"file1.txt", "file2.txt"},
+			expectedPaths:   []string{"file1.txt", "file2.txt"},
+		},
+		{
+			name:            "add empty paths list",
+			existingContent: "existing.txt",
+			newPaths:        []string{},
+			expectedPaths:   []string{"existing.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			var manifestPath string
+
+			if tt.existingContent == "" {
+				manifestPath = filepath.Join(tempDir, ".slop", "context")
+			} else {
+				manifestPath = createManifestFile(t, tempDir, tt.existingContent)
+			}
+
+			manager := NewManifestManager(tempDir)
+			err := manager.AddPaths(manifestPath, tt.newPaths)
+
+			assert.NoError(t, err)
+
+			paths, err := manager.LoadManifest(manifestPath)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedPaths, paths)
+		})
+	}
+}
+
+func TestManifestManager_ClearManifest(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingContent string
+	}{
+		{
+			name:            "clear existing manifest",
+			existingContent: "file1.txt\nfile2.txt\nfile3.txt",
+		},
+		{
+			name:            "clear non-existent manifest",
+			existingContent: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			var manifestPath string
+
+			if tt.existingContent == "" {
+				manifestPath = filepath.Join(tempDir, ".slop", "context")
+			} else {
+				manifestPath = createManifestFile(t, tempDir, tt.existingContent)
+			}
+
+			manager := NewManifestManager(tempDir)
+			err := manager.ClearManifest(manifestPath)
+
+			assert.NoError(t, err)
+			assert.FileExists(t, manifestPath)
+
+			paths, err := manager.LoadManifest(manifestPath)
+			assert.NoError(t, err)
+			assert.Empty(t, paths)
+		})
+	}
+}
+
+func TestManifestManager_LoadProjectContext(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupFunc     func(t *testing.T) string
+		expectedFiles int
+		verifyContent func(t *testing.T, contextFiles []slopContext.ContextFile)
+	}{
+		{
+			name: "success with multiple files",
+			setupFunc: func(t *testing.T) string {
+				tempDir := t.TempDir()
+				file1Path := filepath.Join(tempDir, "file1.txt")
+				file2Path := filepath.Join(tempDir, "subdir", "file2.txt")
+				file3Path := filepath.Join(tempDir, "file3.txt")
+
+				createTestFile(t, file1Path, "Content of file 1")
+				createTestFile(t, file2Path, "Content of file 2")
+				createTestFile(t, file3Path, "Content of file 3\n\n\t  ")
+
+				manifestContent := "file1.txt\nsubdir/file2.txt\nfile3.txt"
+				createManifestFile(t, tempDir, manifestContent)
+				return tempDir
+			},
+			expectedFiles: 3,
+			verifyContent: func(t *testing.T, contextFiles []slopContext.ContextFile) {
+				assert.Equal(t, "Content of file 1", contextFiles[0].Content)
+				assert.Equal(t, "Content of file 2", contextFiles[1].Content)
+				assert.Equal(t, "Content of file 3", contextFiles[2].Content)
+			},
+		},
+		{
+			name: "absolute and relative paths",
+			setupFunc: func(t *testing.T) string {
+				tempDir := t.TempDir()
+				absoluteFile := filepath.Join(os.TempDir(), "absolute_test.txt")
+				createTestFile(t, absoluteFile, "Absolute file content")
+				t.Cleanup(func() { os.Remove(absoluteFile) })
+
+				relativeFile := filepath.Join(tempDir, "relative.txt")
+				createTestFile(t, relativeFile, "Relative file content")
+
+				manifestContent := absoluteFile + "\nrelative.txt"
+				createManifestFile(t, tempDir, manifestContent)
+				return tempDir
+			},
+			expectedFiles: 2,
+			verifyContent: func(t *testing.T, contextFiles []slopContext.ContextFile) {
+				assert.Equal(t, "Absolute file content", contextFiles[0].Content)
+				assert.Equal(t, "Relative file content", contextFiles[1].Content)
+			},
+		},
+		{
+			name: "missing files are skipped",
+			setupFunc: func(t *testing.T) string {
+				tempDir := t.TempDir()
+				validFile := filepath.Join(tempDir, "valid.txt")
+				createTestFile(t, validFile, "Valid content")
+
+				manifestContent := "valid.txt\nmissing.txt\nvalid.txt"
+				createManifestFile(t, tempDir, manifestContent)
+				return tempDir
+			},
+			expectedFiles: 2,
+			verifyContent: func(t *testing.T, contextFiles []slopContext.ContextFile) {
+				assert.Equal(t, "Valid content", contextFiles[0].Content)
+				assert.Equal(t, "Valid content", contextFiles[1].Content)
+			},
+		},
+		{
+			name: "empty files are skipped",
+			setupFunc: func(t *testing.T) string {
+				tempDir := t.TempDir()
+				emptyFile := filepath.Join(tempDir, "empty.txt")
+				whitespaceFile := filepath.Join(tempDir, "whitespace.txt")
+				validFile := filepath.Join(tempDir, "valid.txt")
+
+				createTestFile(t, emptyFile, "")
+				createTestFile(t, whitespaceFile, "   \n\t\r  ")
+				createTestFile(t, validFile, "Valid content")
+
+				manifestContent := "empty.txt\nwhitespace.txt\nvalid.txt"
+				createManifestFile(t, tempDir, manifestContent)
+				return tempDir
+			},
+			expectedFiles: 1,
+			verifyContent: func(t *testing.T, contextFiles []slopContext.ContextFile) {
+				assert.Equal(t, "Valid content", contextFiles[0].Content)
+			},
+		},
+		{
+			name: "no manifest file",
+			setupFunc: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			expectedFiles: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workingDir := tt.setupFunc(t)
+			manager := NewManifestManager(workingDir)
+
+			contextFiles, err := manager.LoadProjectContext()
+
+			assert.NoError(t, err)
+			assert.Len(t, contextFiles, tt.expectedFiles)
+
+			if tt.verifyContent != nil && len(contextFiles) > 0 {
+				tt.verifyContent(t, contextFiles)
+			}
+		})
+	}
+}
+
+func TestManifestManager_GetManifestPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		workingDir string
+		expected   func(string) string
+	}{
+		{
+			name:       "with working directory",
+			workingDir: "/test/path",
+			expected: func(wd string) string {
+				return filepath.Join(wd, ".slop", "context")
+			},
+		},
+		{
+			name:       "with empty working directory",
+			workingDir: "",
+			expected: func(wd string) string {
+				cwd, _ := os.Getwd()
+				return filepath.Join(cwd, ".slop", "context")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManifestManager(tt.workingDir)
+			manifestPath := manager.GetManifestPath()
+
+			expected := tt.expected(tt.workingDir)
+			assert.Equal(t, expected, manifestPath)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces significant updates to core application logic concerning how context files are handled. Additionally, this PR introduces new commands for managing project context files.

### Automatic Persistent Context Loading
- Context files are automatically discovered from `.slop/context` manifest in working directory
- [`internal/cmd/context_commands.go`](diffhunk://#diff-e5d33de6f6e62a364d778d725f5de60b52b915ca0e9fdd2119b71b4fef08bcaaR1-R154) Introduced new commands (`context add`, `context list`, and `context clear`) for managing persistent project context files. 
- Spinner shows context file usage (e.g. "mistral-8b is generating (using 3 project context files)"

### Message Structure
Instead of concatenating all input/context into a single user message, slop now creates a synthetic message history that includes:
1. System message (with format instructions)
2. Context file messages (one per file with "File: path" prefix)
3. Stdin message (if present)
4. Command context message (if present)
5. CLI arg message (final user prompt)

## Documentation
- [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15): Added details about persistent project context functionality, including setup and usage