### PR TITLE
fix: line breaks and default models

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -320,7 +320,7 @@ func executeApp(cmd *cobra.Command, args []string, cfg *config.Config, contextRe
 		return fmt.Errorf("failed to run app: %w", err)
 	}
 
-	fmt.Fprint(cmd.OutOrStdout(), output)
+	fmt.Fprintln(cmd.OutOrStdout(), output)
 	return nil
 }
 

--- a/internal/cmd/selector.go
+++ b/internal/cmd/selector.go
@@ -41,6 +41,9 @@ func (s *DefaultModelSelector) SelectModel(cmd *cobra.Command, cfg *config.Confi
 		useLocal = true
 	} else if remoteFlag, _ := cmd.Flags().GetBool("remote"); remoteFlag {
 		useLocal = false
+	} else if !cmd.Flags().Changed("local") && !cmd.Flags().Changed("remote") {
+		// no flags set, use config default
+		useLocal = cfg.Parameters.DefaultLocation == "local"
 	}
 
 	// determine deep/fast preference
@@ -49,6 +52,9 @@ func (s *DefaultModelSelector) SelectModel(cmd *cobra.Command, cfg *config.Confi
 		useDeep = true
 	} else if fastFlag, _ := cmd.Flags().GetBool("fast"); fastFlag {
 		useDeep = false
+	} else if !cmd.Flags().Changed("deep") && !cmd.Flags().Changed("fast") {
+		// no flags set, use config default
+		useDeep = cfg.Parameters.DefaultModelType == "deep"
 	}
 
 	// select appropriate model config and then validate it


### PR DESCRIPTION
This pull request applies two fixes: improving output formatting in some shells and enhancing the logic for default model configuration handling

* [`internal/cmd/root.go`](diffhunk://#diff-4a72a17fb3924b949e808c07ef6c9bd42c86d326ce47b1e2ac34bd75bb7fe31dL323-R323): Changed `fmt.Fprint` to `fmt.Fprintln` 

* [`internal/cmd/selector.go`](diffhunk://#diff-157803b95e41f8d80748e4b28230ab0a9bd32c738871e5b64377e9878007746cR44-R46): Updated the `SelectModel` method to use default configuration values (`DefaultLocation` and `DefaultModelType`) when neither the `local`/`remote` nor `deep`/`fast` flags are explicitly set.