### PR TITLE
fix: max retry value considers  provider-specific config

### DIFF
--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -54,7 +54,11 @@ Get an API key from https://console.anthropic.com/settings/keys`)
 	if logger != nil {
 		opts = append(opts, common.WithLogger(logger))
 	}
-	maxRetries := cfg.Parameters.MaxRetries
+	// use provider-specific MaxRetries, fall back to global if not set
+	maxRetries := cfg.Providers.Anthropic.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = cfg.Parameters.MaxRetries
+	}
 	if maxRetries > 5 {
 		maxRetries = 5 // enforce maximum limit
 	}

--- a/internal/llm/cohere/provider.go
+++ b/internal/llm/cohere/provider.go
@@ -48,7 +48,11 @@ Get an API key from https://dashboard.cohere.com/api-keys`)
 	if logger != nil {
 		opts = append(opts, common.WithLogger(logger))
 	}
-	maxRetries := cfg.Parameters.MaxRetries
+	// use provider-specific MaxRetries, fall back to global if not set
+	maxRetries := cfg.Providers.Cohere.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = cfg.Parameters.MaxRetries
+	}
 	if maxRetries > 5 {
 		maxRetries = 5 // Enforce maximum limit
 	}

--- a/internal/llm/groq/provider.go
+++ b/internal/llm/groq/provider.go
@@ -53,7 +53,11 @@ Get an API key from https://console.groq.com/keys`)
 	if logger != nil {
 		opts = append(opts, common.WithLogger(logger))
 	}
-	maxRetries := cfg.Parameters.MaxRetries
+	// use provider-specific MaxRetries, fall back to global if not set
+	maxRetries := cfg.Providers.Groq.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = cfg.Parameters.MaxRetries
+	}
 	if maxRetries > 5 {
 		maxRetries = 5 // enforce maximum limit
 	}

--- a/internal/llm/mistral/provider.go
+++ b/internal/llm/mistral/provider.go
@@ -42,7 +42,11 @@ Get an API key from https://console.mistral.ai/api-keys`)
 	if logger != nil {
 		opts = append(opts, common.WithLogger(logger))
 	}
-	maxRetries := cfg.Parameters.MaxRetries
+	// use provider-specific MaxRetries, fall back to global if not set
+	maxRetries := cfg.Providers.Mistral.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = cfg.Parameters.MaxRetries
+	}
 	if maxRetries > 5 {
 		maxRetries = 5 // enforce maximum limit
 	}

--- a/internal/llm/ollama/provider.go
+++ b/internal/llm/ollama/provider.go
@@ -34,7 +34,11 @@ func (p *Provider) CreateClient(cfg *config.Config, logger *slog.Logger) (common
 	if logger != nil {
 		opts = append(opts, common.WithLogger(logger))
 	}
-	maxRetries := cfg.Parameters.MaxRetries
+	// use provider-specific MaxRetries, fall back to global if not set
+	maxRetries := cfg.Providers.Ollama.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = cfg.Parameters.MaxRetries
+	}
 	if maxRetries > 5 {
 		maxRetries = 5 // enforce maximum limit
 	}

--- a/internal/llm/openai/provider.go
+++ b/internal/llm/openai/provider.go
@@ -54,7 +54,11 @@ Get an API key from https://platform.openai.com/api-keys`)
 	if logger != nil {
 		opts = append(opts, common.WithLogger(logger))
 	}
-	maxRetries := cfg.Parameters.MaxRetries
+	// use provider-specific MaxRetries, fall back to global if not set
+	maxRetries := cfg.Providers.OpenAI.MaxRetries
+	if maxRetries == 0 {
+		maxRetries = cfg.Parameters.MaxRetries
+	}
 	if maxRetries > 5 {
 		maxRetries = 5 // enforce maximum limit
 	}


### PR DESCRIPTION
This pull request refines the retry logic for API clients across multiple LLM providers. The changes ensure that each provider can use its specific `MaxRetries` configuration, with a fallback to the global `MaxRetries` setting if the provider-specific value is not set. 

### Retry Logic Updates Across Providers:

* **Anthropic**: Updated `maxRetries` to prioritize `cfg.Providers.Anthropic.MaxRetries` and fall back to `cfg.Parameters.MaxRetries` if unset. Enforced a maximum limit of 5 retries. (`internal/llm/anthropic/provider.go`)
* **Cohere**: Modified `maxRetries` to use `cfg.Providers.Cohere.MaxRetries` with fallback to `cfg.Parameters.MaxRetries`. Enforced a maximum of 5 retries. (`internal/llm/cohere/provider.go`)
* **Groq**: Adjusted `maxRetries` to prioritize `cfg.Providers.Groq.MaxRetries` and default to `cfg.Parameters.MaxRetries` when unset. Enforced a 5-retry maximum. (`internal/llm/groq/provider.go`)
* **Mistral**: Updated `maxRetries` to use `cfg.Providers.Mistral.MaxRetries` with fallback to `cfg.Parameters.MaxRetries`. Enforced a maximum limit of 5 retries. (`internal/llm/mistral/provider.go`)
* **Ollama**: Refined `maxRetries` to prioritize `cfg.Providers.Ollama.MaxRetries` and default to `cfg.Parameters.MaxRetries` if unset. Enforced a maximum of 5 retries. (`internal/llm/ollama/provider.go`)
* **OpenAI**: Adjusted `maxRetries` to use `cfg.Providers.OpenAI.MaxRetries` with fallback to `cfg.Parameters.MaxRetries`. Enforced a maximum limit of 5 retries. (`internal/llm/openai/provider.go`)