### PR TITLE
feat: named commands support message template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Slop
 
 [![Go Version](https://img.shields.io/github/go-mod/go-version/chriscorrea/slop)](go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/chriscorrea/slop)](https://goreportcard.com/report/github.com/chriscorrea/slop)
 [![CI](https://github.com/chriscorrea/slop/actions/workflows/push.yml/badge.svg?branch=main)](https://github.com/chriscorrea/slop/actions/workflows/push.yml)
 [![Latest Release](https://img.shields.io/github/v/release/chriscorrea/slop)](https://github.com/chriscorrea/slop/releases)
 
@@ -190,18 +191,30 @@ To create a new command, add a [commands.<name>] section to the `/.slop/commands
 [commands.review]
 description = "Python code reviewer"
 system_prompt = """You are an expert Python programmer. 
-  Analyze the provided code and deliver a review with a focus on security, performance, and maintainability.
-  Your feedback must be actionable and constructive.
-  For each suggestion, include a 'before' and 'after' code snippet."""
+  Analyze the provided code and deliver a review with a focus on security, performance, and maintainability."""
+
+message_template = """Please review this code: 
+```
+{input}
+```
+List actionable and constructive suggestions and conclude with a improved code snippet."""
+
 model_type = "deep"
 temperature = 0.3
 ```
+
+#### Message Templates
+Named commands support `message_template` to customize how user input is integrated into message.
+
+Use the `{input}` placeholder to substitute user input at the specified location in the template. If no placeholder is specified, the user input will be appended to the templated message. 
 
 #### Usage
 Once configured, you can use your named workflow by passing its name to slop. The command will automatically apply your saved configuration.
 
 ```bash
 cat *.py | slop review
+slop analyze "this function"
+slop docs "the API endpoint"  
 ```
 
 ## 🗄️ Persistent Context

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -284,7 +284,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 }
 
 // executeApp handles the common execution logic for both direct prompts and named commands
-func executeApp(cmd *cobra.Command, args []string, cfg *config.Config, contextResult *slopContext.ContextResult, commandContext string, showCommandInfo bool, commandName string) error {
+func executeApp(cmd *cobra.Command, args []string, cfg *config.Config, contextResult *slopContext.ContextResult, commandContext string, showCommandInfo bool, commandName string, messageTemplate string) error {
 	// select model using the selector
 	providerName, modelName, err := selectModelForCommand(cmd, cfg, commandName, args)
 	if err != nil {
@@ -315,6 +315,7 @@ func executeApp(cmd *cobra.Command, args []string, cfg *config.Config, contextRe
 		commandContext, // command context (empty for a direct prompt)
 		providerName,
 		modelName,
+		messageTemplate,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to run app: %w", err)
@@ -346,8 +347,8 @@ func handleDirectPrompt(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to process context: %w", err)
 	}
 
-	// exec app with no command context, no command info display
-	return executeApp(cmd, args, cfg, contextResult, "", false, "")
+	// exec app with no command context, no command info display, no message template
+	return executeApp(cmd, args, cfg, contextResult, "", false, "", "")
 }
 
 // selectModelForCommand uses the existing model selector logic
@@ -397,7 +398,7 @@ func handleNamedCommand(cmd *cobra.Command, cmdName string, cmdConfig config.Com
 	}
 
 	// exec app with command context and command info display
-	return executeApp(cmd, args, workingConfig, contextResult, cmdConfig.Context, true, cmdName)
+	return executeApp(cmd, args, workingConfig, contextResult, cmdConfig.Context, true, cmdName, cmdConfig.MessageTemplate)
 }
 
 // createListCommand creates the list subcommand

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -117,8 +117,9 @@ type Together struct {
 
 // Command represents a named command with overrideable settings
 type Command struct {
-	Description  string `mapstructure:"description"`
-	SystemPrompt string `mapstructure:"system_prompt"`
+	Description     string `mapstructure:"description"`
+	SystemPrompt    string `mapstructure:"system_prompt"`
+	MessageTemplate string `mapstructure:"message_template"`
 
 	ModelType string `toml:"model_type,omitempty"` // allows local-deep, etc
 


### PR DESCRIPTION
This pull request introduces support for customizable message templates for named commands, enabling users to define how input is integrated into messages. The changes includes updates to the `README.md`, core application logic, and test cases. Key modifications include adding support for the `message_template` field, processing user input with templates, and improving test coverage to validate the new functionality.