### PR TITLE
Conversation Context and Custom Exit Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,33 @@ To receive a structured response, add one of the following flags to your command
 
 Note that format flags are mutually exclusive.
 
+## 🔄 Workflow Exit Codes
+
+Slop can return structured exit codes based on LLM responses, enabling automation and routing in shell scripts and CI/CD pipelines. This makes slop a powerful building block for decision-making workflows.
+
+Exit codes allow you to branch logic based on AI analysis results. The `--sentiment` flag returns exit code 10 for positive responses, 11 for negative, and 12 for neutral. The `--pass-fail` flag returns 30 for pass and 31 for fail. When no pattern matches, slop exits with code 0, preserving composability with other tools.
+
+```bash
+# Route based on sentiment analysis
+if slop --sentiment "The quarterly results exceeded expectations by 15%"; then
+  case $? in
+    10) echo "Positive sentiment detected - sending to marketing team" ;;
+    11) echo "Negative sentiment detected - escalating to management" ;;
+    12) echo "Neutral sentiment - no action needed" ;;
+  esac
+fi
+
+# Automated code review with pass/fail routing
+slop --pass-fail --context main.py "Does this code follow security best practices?" 
+if [ $? -eq 30 ]; then
+  echo "Code passed security review - proceeding with deployment"
+  deploy_to_production
+else
+  echo "Code failed security review - blocking deployment" 
+  exit 1
+fi
+```
+
 ## ⚙️ Configuration
 
 #### Command-Line Configuration

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ Chain multiple slop commands to orchestrate multi-stage solutions:
 
 ```bash
 sift https://www.drought.gov/national 
- pandoc -f html -t plain | \
- slop "Which States are most vulnerable to drought"| \
+ slop "Which states are most vulnerable to drought?"| \
  slop --context RFI-2025-05936.xml \
  "Which proposed data centers are in areas vulnerable to drought?"
 ```
@@ -257,23 +256,23 @@ To receive a structured response, add one of the following flags to your command
 
 Note that format flags are mutually exclusive.
 
-## 🔄 Workflow Exit Codes
+## 🔄 Exit Codes
 
-Slop can return structured exit codes based on LLM responses, enabling automation and routing in shell scripts and CI/CD pipelines. This makes slop a powerful building block for decision-making workflows.
+Structured exit codes can facilitate automation and routing in shell scripts.
 
 Exit codes allow you to branch logic based on AI analysis results. The `--sentiment` flag returns exit code 10 for positive responses, 11 for negative, and 12 for neutral. The `--pass-fail` flag returns 30 for pass and 31 for fail. When no pattern matches, slop exits with code 0, preserving composability with other tools.
 
 ```bash
-# Route based on sentiment analysis
-if slop --sentiment "The quarterly results exceeded expectations by 15%"; then
+# sentiment-based routing
+if slop --sentiment "Let's face it: our lives are miserable, laborious, and short!"; then
   case $? in
-    10) echo "Positive sentiment detected - sending to marketing team" ;;
-    11) echo "Negative sentiment detected - escalating to management" ;;
+    10) echo "Positive sentiment detected - escalating to propaganda team" ;;
+    11) echo "Negative sentiment detected - escalating to quality improvement team" ;;
     12) echo "Neutral sentiment - no action needed" ;;
   esac
 fi
 
-# Automated code review with pass/fail routing
+# code review with pass/fail routing
 slop --pass-fail --context main.py "Does this code follow security best practices?" 
 if [ $? -eq 30 ]; then
   echo "Code passed security review - proceeding with deployment"
@@ -283,6 +282,8 @@ else
   exit 1
 fi
 ```
+
+You can also define custom exit codes in your `config.TOML`
 
 ## ⚙️ Configuration
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -131,9 +131,10 @@ func TestApp_SyntheticMessageHistory_BasicScenario(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
 
 	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "mocked response", result)
 	mockLLM.AssertExpectations(t)
 }
@@ -201,9 +202,10 @@ func TestApp_SyntheticMessageHistory_ContextFiles(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"analyze these files"}, contextResult, "", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"analyze these files"}, contextResult, "", "test-provider", "test-model", "", "")
 
 	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "analysis response", result)
 	mockLLM.AssertExpectations(t)
 }
@@ -269,9 +271,10 @@ func TestApp_SyntheticMessageHistory_ComplexScenario(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"find security vulnerabilities"}, contextResult, "You are reviewing windmill plans", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"find security vulnerabilities"}, contextResult, "You are reviewing windmill plans", "test-provider", "test-model", "", "")
 
 	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "security analysis", result)
 	mockLLM.AssertExpectations(t)
 }
@@ -314,9 +317,10 @@ func TestApp_SyntheticMessageHistory_EmptyContextFiles(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"process files"}, contextResult, "", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"process files"}, contextResult, "", "test-provider", "test-model", "", "")
 
 	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "processed", result)
 	mockLLM.AssertExpectations(t)
 }
@@ -382,9 +386,10 @@ func TestApp_SyntheticMessageHistory_ManyContextFiles(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"summarize all files"}, contextResult, "", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"summarize all files"}, contextResult, "", "test-provider", "test-model", "", "")
 
 	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "summary of all files", result)
 	mockLLM.AssertExpectations(t)
 }
@@ -476,9 +481,10 @@ func TestApp_Run_CreateProvider_Error(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "nonexistent", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "nonexistent", "test-model", "", "")
 
 	assert.Error(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Empty(t, result)
 	assert.Contains(t, err.Error(), "failed to create provider")
 	assert.Contains(t, err.Error(), "unsupported provider 'nonexistent'")
@@ -505,9 +511,10 @@ func TestApp_Run_Generate_Error(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
 
 	assert.Error(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Empty(t, result)
 	assert.Contains(t, err.Error(), "failed to generate response")
 	assert.ErrorIs(t, err, expectedError)
@@ -525,9 +532,10 @@ func TestApp_Run_NoInput_Error(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{}, createEmptyContextResult(), "", "mock", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{}, createEmptyContextResult(), "", "mock", "test-model", "", "")
 
 	assert.Error(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Empty(t, result)
 	assert.Contains(t, err.Error(), "no input provided")
 }
@@ -536,9 +544,10 @@ func TestApp_Run_NilConfig_Error(t *testing.T) {
 	app := NewApp(nil, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
 
 	assert.Error(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Empty(t, result)
 	assert.Contains(t, err.Error(), "configuration is nil")
 }
@@ -574,9 +583,10 @@ func TestApp_Run_FormatEnhancement_JSON(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
 
 	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.NotEmpty(t, result)
 	mockLLM.AssertExpectations(t)
 }
@@ -728,9 +738,10 @@ func TestApp_Run_WithMessageTemplate(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, err := app.Run(ctx, []string{"function main() {}"}, createEmptyContextResult(), "", "test-provider", "test-model", "Please review: {input}")
+	result, exitCode, err := app.Run(ctx, []string{"function main() {}"}, createEmptyContextResult(), "", "test-provider", "test-model", "Please review: {input}", "")
 
 	assert.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
 	assert.Equal(t, "Code review complete", result)
 	mockLLM.AssertExpectations(t)
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -406,7 +406,7 @@ func TestBuildSyntheticMessageHistory_WithStdin(t *testing.T) {
 	}
 
 	// build synthetic message history
-	messages := buildSyntheticMessageHistory(input, "")
+	messages := buildSyntheticMessageHistory(input, nil, "")
 
 	// verify correct order: context files, stdin, command context, CLI args
 	assert.Len(t, messages, 4)
@@ -442,7 +442,7 @@ func TestBuildSyntheticMessageHistory_AllMessageTypes(t *testing.T) {
 	}
 
 	// build synthetic message history
-	messages := buildSyntheticMessageHistory(input, "")
+	messages := buildSyntheticMessageHistory(input, nil, "")
 
 	// verify correct order and count: 2 context files + stdin + command context + CLI args = 5 messages
 	assert.Len(t, messages, 5)
@@ -692,7 +692,7 @@ func TestBuildSyntheticMessageHistory_WithMessageTemplate(t *testing.T) {
 			}
 
 			// build synthetic message history with template
-			messages := buildSyntheticMessageHistory(input, tt.messageTemplate)
+			messages := buildSyntheticMessageHistory(input, nil, tt.messageTemplate)
 
 			if tt.expectedContent == "" {
 				// if expected content is empty, we should have no messages

--- a/internal/app/exit_codes.go
+++ b/internal/app/exit_codes.go
@@ -1,0 +1,263 @@
+// Provides exit code functionality
+//
+// The exit code system supports automatic sentiment analysis and pass/fail detection
+//
+// To extend with additional languages:
+// 1. Add new terms to the appropriate regex patterns below
+// 2. Include language-specific positive/negative/neutral terms
+// 3. Add corresponding test cases in exit_codes_test.go
+//
+// Note: all regex patterns use case-insensitive matching, UTF-8 is supported.
+package app
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// exit codes for built-in modes
+const (
+	ExitPositive = 10
+	ExitNegative = 11
+	ExitNeutral  = 12
+	ExitPass     = 30
+	ExitFail     = 31
+)
+
+// pre-compiled regex patterns for sentiment and pass/fail detection
+// supporting latin scripts: English, Spanish, French, German, Portuguese, Italian, Dutch, Swedish/Norwegian/Danish
+var sentimentRegex = struct {
+	Positive *regexp.Regexp
+	Negative *regexp.Regexp
+	Neutral  *regexp.Regexp
+}{
+	// English and other major Latin-script languages
+	Positive: regexp.MustCompile(`(?i)\b(positive|good|yes|great|excellent|wonderful|fantastic|success|approve|agreed|affirmative|` +
+		// Spanish
+		`bueno|bien|excelente|fantástico|sí|positivo|maravilloso|estupendo|` +
+		// French
+		`bon|bien|excellent|fantastique|oui|positif|merveilleux|formidable|` +
+		// German
+		`gut|ausgezeichnet|fantastisch|ja|positiv|wunderbar|hervorragend|` +
+		// Portuguese
+		`bom|bem|excelente|fantástico|sim|positivo|maravilhoso|ótimo|` +
+		// Italian
+		`buono|bene|eccellente|fantastico|sì|positivo|meraviglioso|ottimo|` +
+		// Dutch
+		`goed|uitstekend|fantastisch|ja|positief|geweldig|prima|` +
+		// Swedish/Norwegian/Danish
+		`bra|utmärkt|fantastisk|ja|positiv|underbar|fremragende)\b`),
+
+	Negative: regexp.MustCompile(`(?i)\b(negative|bad|no|terrible|awful|horrible|fail|error|disapprove|disappointing|denied|` +
+		// Spanish
+		`malo|mal|terrible|horrible|no|negativo|pésimo|desastroso|` +
+		// French
+		`mauvais|mal|terrible|horrible|non|négatif|affreux|désastreux|` +
+		// German
+		`schlecht|schrecklich|furchtbar|nein|negativ|entsetzlich|katastrophal|` +
+		// Portuguese
+		`mau|mal|terrível|horrível|não|negativo|péssimo|desastroso|` +
+		// Italian
+		`cattivo|male|terribile|orribile|no|negativo|pessimo|disastroso|` +
+		// Dutch
+		`slecht|verschrikkelijk|vreselijk|nee|negatief|afschuwelijk|` +
+		// Swedish/Norwegian/Danish
+		`dålig|fruktansvärd|hemsk|nej|negativ|förskräcklig)\b`),
+
+	Neutral: regexp.MustCompile(`(?i)\b(neutral|neither|unclear|ambiguous|uncertain|maybe|mixed|moderate|average|okay|` +
+		// Spanish
+		`neutral|neutro|incierto|promedio|regular|quizás|tal vez|` +
+		// French
+		`neutre|incertain|moyen|peut-être|modéré|` +
+		// German
+		`neutral|ungewiss|durchschnittlich|vielleicht|mittelmäßig|` +
+		// Portuguese
+		`neutro|incerto|médio|talvez|moderado|` +
+		// Italian
+		`neutro|incerto|medio|forse|moderato|` +
+		// Dutch
+		`neutraal|onzeker|gemiddeld|misschien|` +
+		// Swedish/Norwegian/Danish
+		`neutral|osäker|genomsnittlig|kanske|måske)\b`),
+}
+
+var passFailRegex = struct {
+	Pass *regexp.Regexp
+	Fail *regexp.Regexp
+}{
+	// English and other major Latin-script languages
+	Pass: regexp.MustCompile(`(?i)\b(pass|passed|success|approved|accepted|ok|okay|true|correct|valid|successful|` +
+		// Spanish
+		`aprobado|aceptado|correcto|válido|exitoso|verdadero|` +
+		// French
+		`réussi|approuvé|accepté|correct|valide|succès|vrai|` +
+		// German
+		`bestanden|genehmigt|akzeptiert|korrekt|gültig|erfolgreich|richtig|` +
+		// Portuguese
+		`aprovado|aceito|correto|válido|sucesso|verdadeiro|` +
+		// Italian
+		`approvato|accettato|corretto|valido|successo|vero|` +
+		// Dutch
+		`geslaagd|goedgekeurd|geaccepteerd|correct|geldig|succesvol|` +
+		// Swedish/Norwegian/Danish
+		`godkänd|godkjent|accepterad|korrekt|giltig|framgångsrik)\b`),
+
+	Fail: regexp.MustCompile(`(?i)(^|\s|[^\p{L}])(fail|failed|error|rejected|denied|false|incorrect|invalid|unsuccessful|` +
+		// Spanish
+		`fallar|fallado|rechazado|denegado|falso|incorrecto|inválido|fracaso|` +
+		// French
+		`échoué|rejeté|refusé|faux|incorrect|invalide|échec|erreur|` +
+		// German
+		`fehlgeschlagen|abgelehnt|verweigert|falsch|ungültig|fehler|` +
+		// Portuguese
+		`falhou|rejeitado|negado|falso|incorreto|inválido|fracasso|erro|` +
+		// Italian
+		`fallito|respinto|negato|falso|errato|invalido|fallimento|errore|` +
+		// Dutch
+		`mislukt|afgewezen|geweigerd|vals|onjuist|ongeldig|fout|` +
+		// Swedish/Norwegian/Danish
+		`misslyckades|avvisad|nekad|falsk|felaktig|ogiltig|fel)($|\s|[^\p{L}])`),
+}
+
+// regex cache for custom exit code patterns to avoid recompilation
+var (
+	regexCache sync.Map // map[string]*regexp.Regexp
+)
+
+// getCompiledRegex returns a cached compiled regex or compiles and caches a new one
+func getCompiledRegex(pattern string) (*regexp.Regexp, error) {
+	if cached, ok := regexCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp), nil
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	regexCache.Store(pattern, re)
+	return re, nil
+}
+
+// getTextPart extracts partial text based on length and direction
+func getTextPart(text string, length int, fromEnd bool) string {
+	if len(text) <= length {
+		return text
+	}
+
+	if fromEnd {
+		return text[len(text)-length:]
+	}
+	return text[:length]
+}
+
+// determineSentimentExitCode performs a multi-pass check for sentiment
+func determineSentimentExitCode(response string) int {
+	// first pass: strict check on the beginning
+	firstPart := getTextPart(response, 15, false) // first 15 characters
+	if sentimentRegex.Positive.MatchString(firstPart) {
+		return ExitPositive
+	}
+	if sentimentRegex.Negative.MatchString(firstPart) {
+		return ExitNegative
+	}
+	if sentimentRegex.Neutral.MatchString(firstPart) {
+		return ExitNeutral
+	}
+
+	// second pass: check the end
+	lastPart := getTextPart(response, 15, true) // last 15 characters
+	if sentimentRegex.Positive.MatchString(lastPart) {
+		return ExitPositive
+	}
+	if sentimentRegex.Negative.MatchString(lastPart) {
+		return ExitNegative
+	}
+	if sentimentRegex.Neutral.MatchString(lastPart) {
+		return ExitNeutral
+	}
+
+	// third pass: broader check on the beginning
+	introPart := getTextPart(response, 25, false) // first 25 characters
+	if sentimentRegex.Positive.MatchString(introPart) {
+		return ExitPositive
+	}
+	if sentimentRegex.Negative.MatchString(introPart) {
+		return ExitNegative
+	}
+	if sentimentRegex.Neutral.MatchString(introPart) {
+		return ExitNeutral
+	}
+
+	return 0 // no match
+}
+
+// determinePassFailExitCode performs a multi-pass check for pass/fail
+func determinePassFailExitCode(response string) int {
+	// first pass: strict check on the beginning
+	firstPart := getTextPart(response, 15, false)
+	if passFailRegex.Pass.MatchString(firstPart) {
+		return ExitPass
+	}
+	if passFailRegex.Fail.MatchString(firstPart) {
+		return ExitFail
+	}
+
+	// second pass: check the end
+	lastPart := getTextPart(response, 15, true)
+	if passFailRegex.Pass.MatchString(lastPart) {
+		return ExitPass
+	}
+	if passFailRegex.Fail.MatchString(lastPart) {
+		return ExitFail
+	}
+
+	// third pass: broader check on the beginning
+	introPart := getTextPart(response, 25, false)
+	if passFailRegex.Pass.MatchString(introPart) {
+		return ExitPass
+	}
+	if passFailRegex.Fail.MatchString(introPart) {
+		return ExitFail
+	}
+
+	return 0 // no match
+}
+
+// determineCustomExitCode handles user-defined maps from the config file
+func (a *App) determineCustomExitCode(response string, exitCodeMapName string) int {
+	if exitCodeMapName == "" {
+		return 0
+	}
+	exitMap, ok := a.cfg.ExitCodes[exitCodeMapName]
+	if !ok {
+		a.logger.Warn("Specified exit code map not found", "map_name", exitCodeMapName)
+		return 0
+	}
+	for _, rule := range exitMap.Rules {
+		match := false
+		switch rule.MatchType {
+		case "exact":
+			match = (response == rule.Pattern)
+		case "contains":
+			match = strings.Contains(response, rule.Pattern)
+		case "prefix":
+			match = strings.HasPrefix(response, rule.Pattern)
+		case "suffix":
+			match = strings.HasSuffix(response, rule.Pattern)
+		case "regex":
+			re, err := getCompiledRegex(rule.Pattern)
+			if err != nil {
+				a.logger.Error("Invalid regex in exit code rule", "pattern", rule.Pattern, "error", err)
+				continue
+			}
+			match = re.MatchString(response)
+		}
+		if match {
+			a.logger.Debug("Exit code rule matched", "pattern", rule.Pattern, "exit_code", rule.ExitCode)
+			return rule.ExitCode
+		}
+	}
+	return 0 // no match
+}

--- a/internal/app/exit_codes_test.go
+++ b/internal/app/exit_codes_test.go
@@ -346,6 +346,23 @@ func TestDetermineCustomExitCode(t *testing.T) {
 					{MatchType: "exact", Pattern: "fallback", ExitCode: 401},
 				},
 			},
+			// Default config examples - these match the actual default_config.toml
+			"approval": {
+				Description: "Exits based on a three-stage approval status.",
+				Rules: []config.ExitCodeRule{
+					{MatchType: "contains", Pattern: "APPROVED", ExitCode: 20},
+					{MatchType: "contains", Pattern: "REJECTED", ExitCode: 21},
+					{MatchType: "contains", Pattern: "NEEDS_REVIEW", ExitCode: 22},
+				},
+			},
+			"priority": {
+				Description: "Exit codes based on priority levels.",
+				Rules: []config.ExitCodeRule{
+					{MatchType: "regex", Pattern: "(?i)\\b(urgent|critical|high)\\b", ExitCode: 30},
+					{MatchType: "regex", Pattern: "(?i)\\b(medium|normal)\\b", ExitCode: 31},
+					{MatchType: "regex", Pattern: "(?i)\\b(low|minor)\\b", ExitCode: 32},
+				},
+			},
 		},
 	}
 
@@ -422,6 +439,82 @@ func TestDetermineCustomExitCode(t *testing.T) {
 			name:            "Non-existent map",
 			response:        "MIX",
 			exitCodeMapName: "non_existent",
+			expected:        0,
+		},
+
+		// Default config examples verification
+		{
+			name:            "Approval APPROVED",
+			response:        "The deployment has been APPROVED for production",
+			exitCodeMapName: "approval",
+			expected:        20,
+		},
+		{
+			name:            "Approval REJECTED",
+			response:        "Request REJECTED due to security concerns",
+			exitCodeMapName: "approval",
+			expected:        21,
+		},
+		{
+			name:            "Approval NEEDS_REVIEW",
+			response:        "Code NEEDS_REVIEW before deployment",
+			exitCodeMapName: "approval",
+			expected:        22,
+		},
+		{
+			name:            "Approval no match",
+			response:        "Status is pending further analysis",
+			exitCodeMapName: "approval",
+			expected:        0,
+		},
+
+		// Priority level tests
+		{
+			name:            "Priority urgent",
+			response:        "This is an urgent security vulnerability",
+			exitCodeMapName: "priority",
+			expected:        30,
+		},
+		{
+			name:            "Priority critical case insensitive",
+			response:        "CRITICAL system failure detected",
+			exitCodeMapName: "priority",
+			expected:        30,
+		},
+		{
+			name:            "Priority high",
+			response:        "High priority bug needs immediate attention",
+			exitCodeMapName: "priority",
+			expected:        30,
+		},
+		{
+			name:            "Priority medium",
+			response:        "This has medium priority for next sprint",
+			exitCodeMapName: "priority",
+			expected:        31,
+		},
+		{
+			name:            "Priority normal",
+			response:        "Normal maintenance task",
+			exitCodeMapName: "priority",
+			expected:        31,
+		},
+		{
+			name:            "Priority low",
+			response:        "Low priority enhancement request",
+			exitCodeMapName: "priority",
+			expected:        32,
+		},
+		{
+			name:            "Priority minor",
+			response:        "Minor documentation update needed",
+			exitCodeMapName: "priority",
+			expected:        32,
+		},
+		{
+			name:            "Priority no match",
+			response:        "Status unknown at this time",
+			exitCodeMapName: "priority",
 			expected:        0,
 		},
 	}

--- a/internal/app/exit_codes_test.go
+++ b/internal/app/exit_codes_test.go
@@ -1,0 +1,435 @@
+package app
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/chriscorrea/slop/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineSentimentExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		expected int
+	}{
+		{
+			name:     "Positive at start",
+			response: "PoSiTiVe - this is an example of great news",
+			expected: ExitPositive,
+		},
+		{
+			name:     "Negative at start",
+			response: "NEGATIVE - this is bad",
+			expected: ExitNegative,
+		},
+		{
+			name:     "Neutral at start",
+			response: "neutral - neither good nor bad",
+			expected: ExitNeutral,
+		},
+		{
+			name:     "Positive later in response",
+			response: "The result is positive, subsequent text goes here",
+			expected: ExitPositive,
+		},
+		{
+			name:     "Negative later in response",
+			response: "The result is negative, subsequent text goes here",
+			expected: ExitNegative,
+		},
+		{
+			name:     "No match",
+			response: "The carrot cake is edible",
+			expected: 0,
+		},
+		// multilingual tests - Spanish
+		{
+			name:     "Spanish positive",
+			response: "bueno, el resultado es excelente",
+			expected: ExitPositive,
+		},
+		{
+			name:     "Spanish negative",
+			response: "malo, esto es terrible",
+			expected: ExitNegative,
+		},
+		{
+			name:     "Spanish neutral",
+			response: "neutro, es regular",
+			expected: ExitNeutral,
+		},
+		// multilingual tests - French
+		{
+			name:     "French positive",
+			response: "bon travail, c'est excellent",
+			expected: ExitPositive,
+		},
+		{
+			name:     "French negative",
+			response: "mauvais résultat, c'est horrible",
+			expected: ExitNegative,
+		},
+		{
+			name:     "French neutral",
+			response: "neutre, c'est moyen",
+			expected: ExitNeutral,
+		},
+		// multilingual tests - German
+		{
+			name:     "German positive",
+			response: "gut gemacht, ausgezeichnet!",
+			expected: ExitPositive,
+		},
+		{
+			name:     "German negative",
+			response: "schlecht, das ist furchtbar",
+			expected: ExitNegative,
+		},
+		{
+			name:     "German neutral",
+			response: "neutral, durchschnittlich",
+			expected: ExitNeutral,
+		},
+		// multilingual tests - Portuguese
+		{
+			name:     "Portuguese positive",
+			response: "bom trabalho, fantástico!",
+			expected: ExitPositive,
+		},
+		{
+			name:     "Portuguese negative",
+			response: "mau resultado, terrível",
+			expected: ExitNegative,
+		},
+		// multilingual tests - Italian
+		{
+			name:     "Italian positive",
+			response: "buono, eccellente lavoro",
+			expected: ExitPositive,
+		},
+		{
+			name:     "Italian negative",
+			response: "cattivo, è orribile",
+			expected: ExitNegative,
+		},
+		// multilingual tests - Dutch
+		{
+			name:     "Dutch positive",
+			response: "goed gedaan, fantastisch!",
+			expected: ExitPositive,
+		},
+		{
+			name:     "Dutch negative",
+			response: "slecht, verschrikkelijk",
+			expected: ExitNegative,
+		},
+		// multilingual tests - Nordic
+		{
+			name:     "Swedish positive",
+			response: "bra jobbat, utmärkt!",
+			expected: ExitPositive,
+		},
+		{
+			name:     "Nordic negative",
+			response: "dålig, fruktansvärd",
+			expected: ExitNegative,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determineSentimentExitCode(tt.response)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDeterminePassFailExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		expected int
+	}{
+		{
+			name:     "Pass at start",
+			response: "PASS - all tests successful",
+			expected: ExitPass,
+		},
+		{
+			name:     "Fail at start",
+			response: "FAIL - tests failed",
+			expected: ExitFail,
+		},
+		{
+			name:     "Success synonym",
+			response: "SUCCESS - operation completed",
+			expected: ExitPass,
+		},
+		{
+			name:     "Error synonym",
+			response: "ERROR - something went wrong",
+			expected: ExitFail,
+		},
+		{
+			name:     "No match",
+			response: "The process is running",
+			expected: 0,
+		},
+		{
+			name:     "Case insensitive",
+			response: "failed to connect",
+			expected: ExitFail,
+		},
+		// multilingual tests - Spanish
+		{
+			name:     "Spanish pass",
+			response: "aprobado - todo correcto",
+			expected: ExitPass,
+		},
+		{
+			name:     "Spanish fail",
+			response: "rechazado - hay errores",
+			expected: ExitFail,
+		},
+		// multilingual tests - French
+		{
+			name:     "French pass",
+			response: "réussi - tout est correct",
+			expected: ExitPass,
+		},
+		{
+			name:     "French fail",
+			response: "échoué - il y a des erreurs",
+			expected: ExitFail,
+		},
+		// multilingual tests - German
+		{
+			name:     "German pass",
+			response: "bestanden - alles korrekt",
+			expected: ExitPass,
+		},
+		{
+			name:     "German fail",
+			response: "fehlgeschlagen - es gibt Fehler",
+			expected: ExitFail,
+		},
+		// multilingual tests - Portuguese
+		{
+			name:     "Portuguese pass",
+			response: "aprovado com sucesso",
+			expected: ExitPass,
+		},
+		{
+			name:     "Portuguese fail",
+			response: "falhou - erro encontrado",
+			expected: ExitFail,
+		},
+		// multilingual tests - Italian
+		{
+			name:     "Italian pass",
+			response: "approvato - tutto corretto",
+			expected: ExitPass,
+		},
+		{
+			name:     "Italian fail",
+			response: "fallito - errore trovato",
+			expected: ExitFail,
+		},
+		// multilingual tests - Dutch
+		{
+			name:     "Dutch pass",
+			response: "geslaagd - alles correct",
+			expected: ExitPass,
+		},
+		{
+			name:     "Dutch fail",
+			response: "mislukt - fout gevonden",
+			expected: ExitFail,
+		},
+		// multilingual tests - Nordic
+		{
+			name:     "Swedish pass",
+			response: "godkänd - allt korrekt",
+			expected: ExitPass,
+		},
+		{
+			name:     "Nordic fail",
+			response: "misslyckades - fel hittades",
+			expected: ExitFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := determinePassFailExitCode(tt.response)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEnhanceSystemPromptForExitCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		basePrompt string
+		exitMode   string
+		expected   string
+	}{
+		{
+			name:       "Sentiment mode with base prompt",
+			basePrompt: "You are a helpful baker.",
+			exitMode:   "sentiment",
+			expected:   "You are a helpful baker.\n\nIMPORTANT: Start your response with exactly one of these words: POSITIVE, NEGATIVE, or NEUTRAL. Be direct and clear.",
+		},
+		{
+			name:       "Pass-fail mode with base prompt",
+			basePrompt: "You are a helpful baker.",
+			exitMode:   "pass-fail",
+			expected:   "You are a helpful baker.\n\nIMPORTANT: Start your response with exactly one of these words: PASS or FAIL. Be direct and clear.",
+		},
+		{
+			name:       "Sentiment mode with empty base prompt",
+			basePrompt: "",
+			exitMode:   "sentiment",
+			expected:   "IMPORTANT: Start your response with exactly one of these words: POSITIVE, NEGATIVE, or NEUTRAL. Be direct and clear.",
+		},
+		{
+			name:       "No exit mode",
+			basePrompt: "You are helpful",
+			exitMode:   "",
+			expected:   "You are helpful",
+		},
+		{
+			name:       "Unknown exit mode",
+			basePrompt: "You are helpful",
+			exitMode:   "unknown",
+			expected:   "You are helpful",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := enhanceSystemPromptForExitCode(tt.basePrompt, tt.exitMode)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetermineCustomExitCode(t *testing.T) {
+	// create mock app with logger and config
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// define test exit code maps
+	testConfig := &config.Config{
+		ExitCodes: map[string]config.ExitCodeMap{
+			"bakery": {
+				Description: "Bakery workflow steps",
+				Rules: []config.ExitCodeRule{
+					{MatchType: "exact", Pattern: "MIX", ExitCode: 100},
+					{MatchType: "exact", Pattern: "BAKE", ExitCode: 101},
+					{MatchType: "prefix", Pattern: "COOL", ExitCode: 102},
+				},
+			},
+			"priority_order": {
+				Description: "Tests rule priority - first match wins",
+				Rules: []config.ExitCodeRule{
+					{MatchType: "contains", Pattern: "test", ExitCode: 300},
+					{MatchType: "contains", Pattern: "test completed", ExitCode: 301}, // should not match if "test" matches first
+				},
+			},
+			"invalid_regex": {
+				Description: "Contains invalid regex pattern",
+				Rules: []config.ExitCodeRule{
+					{MatchType: "regex", Pattern: "[invalid", ExitCode: 400}, // invalid regex
+					{MatchType: "exact", Pattern: "fallback", ExitCode: 401},
+				},
+			},
+		},
+	}
+
+	app := &App{
+		cfg:    testConfig,
+		logger: logger,
+	}
+
+	tests := []struct {
+		name            string
+		response        string
+		exitCodeMapName string
+		expected        int
+	}{
+		// bakery workflow example tests
+		{
+			name:            "Bakery MIX step",
+			response:        "MIX",
+			exitCodeMapName: "bakery",
+			expected:        100,
+		},
+		{
+			name:            "Bakery BAKE step",
+			response:        "BAKE",
+			exitCodeMapName: "bakery",
+			expected:        101,
+		},
+		{
+			name:            "Bakery COOL step",
+			response:        "COOL for 20 minutes", //prefix
+			exitCodeMapName: "bakery",
+			expected:        102,
+		},
+		{
+			name:            "Bakery step in sentence",
+			response:        "Next step is to BAKE the cake",
+			exitCodeMapName: "bakery",
+			expected:        0, // exact match required
+		},
+		{
+			name:            "Bakery no match",
+			response:        "SERVE",
+			exitCodeMapName: "bakery",
+			expected:        0,
+		},
+		// Priority order tests
+		{
+			name:            "First rule wins",
+			response:        "test completed successfully",
+			exitCodeMapName: "priority_order",
+			expected:        300, // Should match first "test" rule, not "test completed"
+		},
+
+		// Error handling tests
+		{
+			name:            "Invalid regex pattern",
+			response:        "This should trigger invalid regex",
+			exitCodeMapName: "invalid_regex",
+			expected:        0, // Should skip invalid regex and not match anything
+		},
+		{
+			name:            "Invalid regex with fallback match",
+			response:        "fallback",
+			exitCodeMapName: "invalid_regex",
+			expected:        401, // Should skip invalid regex but match exact pattern
+		},
+		{
+			name:            "Empty map name",
+			response:        "MIX",
+			exitCodeMapName: "",
+			expected:        0,
+		},
+		{
+			name:            "Non-existent map",
+			response:        "MIX",
+			exitCodeMapName: "non_existent",
+			expected:        0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := app.determineCustomExitCode(tt.response, tt.exitCodeMapName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/app/exit_codes_test.go
+++ b/internal/app/exit_codes_test.go
@@ -392,7 +392,7 @@ func TestDetermineCustomExitCode(t *testing.T) {
 		},
 		{
 			name:            "Bakery COOL step",
-			response:        "COOL for 20 minutes", //prefix
+			response:        "COOL for 20 minutes", // prefix
 			exitCodeMapName: "bakery",
 			expected:        102,
 		},

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -125,10 +125,8 @@ func (c *DefaultContextManager) processContextFile(path string, content string, 
 				Type:     "conversation",
 				Messages: messages,
 			}
-		} else {
-			if logger != nil {
-				logger.Debug("Context file has conversation extension but failed parsing, treating as text", "file", path, "error", err)
-			}
+		} else if logger != nil {
+			logger.Debug("Context file has conversation extension but failed parsing, treating as text", "file", path, "error", err)
 		}
 	}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 )
 
 // current version (hardcoded for now, could be replaced with build flags)
-const version = "0.1.0"
+const version = "0.1.3"
 
 // rootCmdState holds the config manager and logger for the command
 type rootCmdState struct {

--- a/internal/config/data/default_config.toml
+++ b/internal/config/data/default_config.toml
@@ -71,14 +71,6 @@ xml = false
 # Exit code maps for workflow automation
 [exit_codes]
 
-  [exit_codes.sentiment_custom]
-    description = "A custom map for sentiment. Note: --exit-sentiment flag is preferred."
-    rules = [
-      { match_type = "exact", pattern = "POSITIVE", exit_code = 10 },
-      { match_type = "exact", pattern = "NEGATIVE", exit_code = 11 },
-      { match_type = "exact", pattern = "NEUTRAL",  exit_code = 12 },
-    ]
-
   [exit_codes.approval]
     description = "Exits based on a three-stage approval status."
     rules = [

--- a/internal/config/data/default_config.toml
+++ b/internal/config/data/default_config.toml
@@ -67,3 +67,30 @@ jsonl = false
 yaml = false
 md = false
 xml = false
+
+# Exit code maps for workflow automation
+[exit_codes]
+
+  [exit_codes.sentiment_custom]
+    description = "A custom map for sentiment. Note: --exit-sentiment flag is preferred."
+    rules = [
+      { match_type = "exact", pattern = "POSITIVE", exit_code = 10 },
+      { match_type = "exact", pattern = "NEGATIVE", exit_code = 11 },
+      { match_type = "exact", pattern = "NEUTRAL",  exit_code = 12 },
+    ]
+
+  [exit_codes.approval]
+    description = "Exits based on a three-stage approval status."
+    rules = [
+      { match_type = "contains", pattern = "APPROVED", exit_code = 20 },
+      { match_type = "contains", pattern = "REJECTED", exit_code = 21 },
+      { match_type = "contains", pattern = "NEEDS_REVIEW", exit_code = 22 },
+    ]
+
+  [exit_codes.priority]
+    description = "Exit codes based on priority levels."
+    rules = [
+      { match_type = "regex", pattern = "(?i)\\b(urgent|critical|high)\\b", exit_code = 30 },
+      { match_type = "regex", pattern = "(?i)\\b(medium|normal)\\b", exit_code = 31 },
+      { match_type = "regex", pattern = "(?i)\\b(low|minor)\\b", exit_code = 32 },
+    ]

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -2,12 +2,12 @@ package config
 
 // Config represents the complete configuration structure for slop
 type Config struct {
-	Parameters Parameters         `mapstructure:"parameters"`
-	Models     Models             `mapstructure:"models"`
-	Providers  Providers          `mapstructure:"providers"`
-	Commands   map[string]Command `mapstructure:"commands"`
+	Parameters Parameters             `mapstructure:"parameters"`
+	Models     Models                 `mapstructure:"models"`
+	Providers  Providers              `mapstructure:"providers"`
+	Commands   map[string]Command     `mapstructure:"commands"`
 	ExitCodes  map[string]ExitCodeMap `mapstructure:"exit_codes"`
-	Format     Format             `mapstructure:"format"`
+	Format     Format                 `mapstructure:"format"`
 }
 
 // Parameters contains default configuration values and model selection preferences
@@ -19,15 +19,15 @@ type Parameters struct {
 	TopP          float64  `mapstructure:"top_p"`
 	StopSequences []string `mapstructure:"stop_sequences"`
 	Stream        bool     `mapstructure:"stream"`
-	Seed          *int     `mapstructure:"seed"` // Random seed for deterministic outputs (nil = no seed)
+	Seed          *int     `mapstructure:"seed"`
 
 	// default model selection preferences
 	DefaultModelType string `mapstructure:"default_model_type"` // "fast" or "deep"
 	DefaultLocation  string `mapstructure:"default_location"`   // "local" or "remote"
 
 	// application behavior
-	Timeout    int `mapstructure:"timeout"`     // Timeout in seconds for requests
-	MaxRetries int `mapstructure:"max_retries"` // Maximum number of retry attempts for failed requests
+	Timeout    int `mapstructure:"timeout"`
+	MaxRetries int `mapstructure:"max_retries"`
 }
 
 // Format contains output formatting options
@@ -39,14 +39,14 @@ type Format struct {
 	XML   bool `mapstructure:"xml"`
 }
 
-// ExitCodeRule defines a pattern and exit code for a workflow
+// ExitCodeRule defines a pattern and exit code
 type ExitCodeRule struct {
 	MatchType string `mapstructure:"match_type"` // "exact", "contains", "regex", "prefix", "suffix"
 	Pattern   string `mapstructure:"pattern"`
 	ExitCode  int    `mapstructure:"exit_code"`
 }
 
-// ExitCodeMap is a named set of rules for determining a workflow exit code
+// ExitCodeMap is a named set of rules for determining an exit code
 type ExitCodeMap struct {
 	Description string         `mapstructure:"description"`
 	Rules       []ExitCodeRule `mapstructure:"rules"`
@@ -137,16 +137,16 @@ type Command struct {
 
 	ModelType string `toml:"model_type,omitempty"` // allows local-deep, etc
 
-	// Generation parameters
+	// generation params
 	Temperature *float64 `mapstructure:"temperature"`
 	MaxTokens   *int     `mapstructure:"max_tokens"`
 
-	// Context support - both direct and file-based
+	// context (supports both direct and file-based)
 	Context      string   `mapstructure:"context"`       // direct context string (supports multiline)
 	ContextFiles []string `mapstructure:"context_files"` // file paths to include
 
-	// Exit code configuration
-	ExitCodeMap string `mapstructure:"exit_code_map"` // name of exit code map to use
+	// exit code config
+	ExitCodeMap string `mapstructure:"exit_code_map"` // exit code map name
 }
 
 // ReservedCommands are command names that cannot be overridden by users

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,6 +6,7 @@ type Config struct {
 	Models     Models             `mapstructure:"models"`
 	Providers  Providers          `mapstructure:"providers"`
 	Commands   map[string]Command `mapstructure:"commands"`
+	ExitCodes  map[string]ExitCodeMap `mapstructure:"exit_codes"`
 	Format     Format             `mapstructure:"format"`
 }
 
@@ -36,6 +37,19 @@ type Format struct {
 	YAML  bool `mapstructure:"yaml"`
 	MD    bool `mapstructure:"md"`
 	XML   bool `mapstructure:"xml"`
+}
+
+// ExitCodeRule defines a pattern and exit code for a workflow
+type ExitCodeRule struct {
+	MatchType string `mapstructure:"match_type"` // "exact", "contains", "regex", "prefix", "suffix"
+	Pattern   string `mapstructure:"pattern"`
+	ExitCode  int    `mapstructure:"exit_code"`
+}
+
+// ExitCodeMap is a named set of rules for determining a workflow exit code
+type ExitCodeMap struct {
+	Description string         `mapstructure:"description"`
+	Rules       []ExitCodeRule `mapstructure:"rules"`
 }
 
 // Models contains model configuration for different categories
@@ -130,6 +144,9 @@ type Command struct {
 	// Context support - both direct and file-based
 	Context      string   `mapstructure:"context"`       // direct context string (supports multiline)
 	ContextFiles []string `mapstructure:"context_files"` // file paths to include
+
+	// Exit code configuration
+	ExitCodeMap string `mapstructure:"exit_code_map"` // name of exit code map to use
 }
 
 // ReservedCommands are command names that cannot be overridden by users

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -1,9 +1,19 @@
 package context
 
+import "github.com/chriscorrea/slop/internal/llm/common"
+
 // ContextFile represents a single context file with its path and content
 type ContextFile struct {
 	Path    string
 	Content string
+}
+
+// ContextItem represents a processed context item with type information
+type ContextItem struct {
+	Path     string           // file path
+	Type     string           // "conversation" or "file"
+	Messages []common.Message // for conversations
+	Content  string           // for raw files
 }
 
 // ContextResult contains the result of context processing
@@ -13,6 +23,8 @@ type ContextResult struct {
 	CmdContextFiles []string
 	// Structured context data for synthetic message history
 	ContextFileContents []ContextFile
+	// Enhanced structured context data with conversation detection
+	ProcessedItems []ContextItem
 }
 
 // HasContextFiles returns true if any context files are present

--- a/internal/parser/conversation.go
+++ b/internal/parser/conversation.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/chriscorrea/slop/internal/llm/common"
+)
+
+var (
+	// userPattern matches "User: content" or "**User:** content"
+	userPattern = regexp.MustCompile(`^(?:(?i:user):\s*|\*\*(?i:user):\*\*\s*)(.*)$`)
+	// assistantPattern matches "Assistant: content" or "**Assistant:** content"  
+	assistantPattern = regexp.MustCompile(`^(?:(?i:assistant):\s*|\*\*(?i:assistant):\*\*\s*)(.*)$`)
+)
+
+// ParseJSONHistory attempts to parse content as a JSON array of messages
+func ParseJSONHistory(content []byte) ([]common.Message, error) {
+	var messages []common.Message
+	if err := json.Unmarshal(content, &messages); err != nil {
+		return nil, err
+	}
+
+	// validate message structure
+	for i, msg := range messages {
+		if msg.Role != "user" && msg.Role != "assistant" && msg.Role != "system" {
+			return nil, fmt.Errorf("invalid role '%s' in message %d", msg.Role, i)
+		}
+		if strings.TrimSpace(msg.Content) == "" {
+			return nil, fmt.Errorf("empty message content in message %d", i)
+		}
+	}
+
+	return messages, nil
+}
+
+// ParseTextHistory attempts to parse text content as a conversation
+// Supports formats like "User: message" and "Assistant: message"
+func ParseTextHistory(content string) ([]common.Message, error) {
+	var messages []common.Message
+	lines := strings.Split(content, "\n")
+
+	var currentRole, currentContent string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if match := userPattern.FindStringSubmatch(line); match != nil {
+			// save previous message if exists
+			if currentRole != "" && strings.TrimSpace(currentContent) != "" {
+				messages = append(messages, common.Message{
+					Role:    currentRole,
+					Content: strings.TrimSpace(currentContent),
+				})
+			}
+			currentRole = "user"
+			currentContent = match[1] // captured content after "User:"
+		} else if match := assistantPattern.FindStringSubmatch(line); match != nil {
+			// save previous message if exists
+			if currentRole != "" && strings.TrimSpace(currentContent) != "" {
+				messages = append(messages, common.Message{
+					Role:    currentRole,
+					Content: strings.TrimSpace(currentContent),
+				})
+			}
+			currentRole = "assistant"
+			currentContent = match[1] // captured content after "Assistant:"
+		} else if currentRole != "" {
+			// continue building current message content
+			if currentContent != "" {
+				currentContent += "\n" + line
+			} else {
+				currentContent = line
+			}
+		}
+		// ignore lines that don't match patterns and aren't part of an existing message
+	}
+
+	// save final message
+	if currentRole != "" && strings.TrimSpace(currentContent) != "" {
+		messages = append(messages, common.Message{
+			Role:    currentRole,
+			Content: strings.TrimSpace(currentContent),
+		})
+	}
+
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("no conversation messages found")
+	}
+
+	return messages, nil
+}
+
+// IsConversationFile checks if a file might be a conversation based on extension
+func IsConversationFile(filename string) bool {
+	lower := strings.ToLower(filename)
+	return strings.HasSuffix(lower, ".conversation") ||
+		strings.HasSuffix(lower, ".chat") ||
+		strings.HasSuffix(lower, ".history")
+}

--- a/internal/parser/conversation.go
+++ b/internal/parser/conversation.go
@@ -12,11 +12,11 @@ import (
 var (
 	// userPattern matches "User: content" or "**User:** content"
 	userPattern = regexp.MustCompile(`^(?:(?i:user):\s*|\*\*(?i:user):\*\*\s*)(.*)$`)
-	// assistantPattern matches "Assistant: content" or "**Assistant:** content"  
+	// assistantPattern matches "Assistant: content" or "**Assistant:** content"
 	assistantPattern = regexp.MustCompile(`^(?:(?i:assistant):\s*|\*\*(?i:assistant):\*\*\s*)(.*)$`)
 )
 
-// ParseJSONHistory attempts to parse content as a JSON array of messages
+// ParseJSONHistory attempts to parse as a JSON array of messages
 func ParseJSONHistory(content []byte) ([]common.Message, error) {
 	var messages []common.Message
 	if err := json.Unmarshal(content, &messages); err != nil {
@@ -37,7 +37,7 @@ func ParseJSONHistory(content []byte) ([]common.Message, error) {
 }
 
 // ParseTextHistory attempts to parse text content as a conversation
-// Supports formats like "User: message" and "Assistant: message"
+// supports formats like "User: message" and "Assistant: message"
 func ParseTextHistory(content string) ([]common.Message, error) {
 	var messages []common.Message
 	lines := strings.Split(content, "\n")

--- a/internal/parser/conversation_test.go
+++ b/internal/parser/conversation_test.go
@@ -12,9 +12,9 @@ func TestParseJSONHistory_Valid(t *testing.T) {
 		{"role": "assistant", "content": "Hi there!"},
 		{"role": "user", "content": "How are you?"}
 	]`
-	
+
 	messages, err := ParseJSONHistory([]byte(content))
-	
+
 	assert.NoError(t, err)
 	assert.Len(t, messages, 3)
 	assert.Equal(t, "user", messages[0].Role)
@@ -30,9 +30,9 @@ func TestParseJSONHistory_InvalidJSON(t *testing.T) {
 		{"role": "user", "content": "Hello",
 		{"role": "assistant", "content": "Hi there!"}
 	]`
-	
+
 	messages, err := ParseJSONHistory([]byte(content))
-	
+
 	assert.Error(t, err)
 	assert.Nil(t, messages)
 }
@@ -42,9 +42,9 @@ func TestParseJSONHistory_InvalidRole(t *testing.T) {
 		{"role": "user", "content": "Hello"},
 		{"role": "invalid", "content": "Bad role"}
 	]`
-	
+
 	messages, err := ParseJSONHistory([]byte(content))
-	
+
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid role 'invalid'")
 	assert.Nil(t, messages)
@@ -55,41 +55,41 @@ func TestParseJSONHistory_EmptyContent(t *testing.T) {
 		{"role": "user", "content": "Hello"},
 		{"role": "assistant", "content": ""}
 	]`
-	
+
 	messages, err := ParseJSONHistory([]byte(content))
-	
+
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "empty message content")
 	assert.Nil(t, messages)
 }
 
 func TestParseTextHistory_Valid(t *testing.T) {
-	content := `User: What is the capital of France?
-Assistant: The capital of France is Paris.
+	content := `User: What is the best pastry in all of France?
+Assistant: The best pastry in France is the croissant.
 User: What about Italy?
-Assistant: The capital of Italy is Rome.`
-	
+Assistant: The best pastry in Italy is the cannoli.`
+
 	messages, err := ParseTextHistory(content)
-	
+
 	assert.NoError(t, err)
 	assert.Len(t, messages, 4)
 	assert.Equal(t, "user", messages[0].Role)
-	assert.Equal(t, "What is the capital of France?", messages[0].Content)
+	assert.Equal(t, "What is the best pastry in all of France?", messages[0].Content)
 	assert.Equal(t, "assistant", messages[1].Role)
-	assert.Equal(t, "The capital of France is Paris.", messages[1].Content)
+	assert.Equal(t, "The best pastry in France is the croissant.", messages[1].Content)
 	assert.Equal(t, "user", messages[2].Role)
 	assert.Equal(t, "What about Italy?", messages[2].Content)
 	assert.Equal(t, "assistant", messages[3].Role)
-	assert.Equal(t, "The capital of Italy is Rome.", messages[3].Content)
+	assert.Equal(t, "The best pastry in Italy is the cannoli.", messages[3].Content)
 }
 
 func TestParseTextHistory_MarkdownFormat(t *testing.T) {
 	content := `**User:** What is 2 + 2?
 **Assistant:** 2 + 2 equals 4.
 **User:** Thanks!`
-	
+
 	messages, err := ParseTextHistory(content)
-	
+
 	assert.NoError(t, err)
 	assert.Len(t, messages, 3)
 	assert.Equal(t, "user", messages[0].Role)
@@ -104,21 +104,21 @@ func TestParseTextHistory_MultilineContent(t *testing.T) {
 	content := `User: Can you write a haiku?
 Assistant: Here's a haiku for you:
 
-Code flows like water
-Functions dance in harmony
-Bugs hide in shadows
+sweet roots nestled deep
+cinnamon whispers, softly
+memories rising
 
 User: Beautiful, thanks!`
-	
+
 	messages, err := ParseTextHistory(content)
-	
+
 	assert.NoError(t, err)
 	assert.Len(t, messages, 3)
 	assert.Equal(t, "user", messages[0].Role)
 	assert.Equal(t, "Can you write a haiku?", messages[0].Content)
 	assert.Equal(t, "assistant", messages[1].Role)
 	assert.Contains(t, messages[1].Content, "Here's a haiku for you:")
-	assert.Contains(t, messages[1].Content, "Code flows like water")
+	assert.Contains(t, messages[1].Content, "cinnamon whispers")
 	assert.Equal(t, "user", messages[2].Role)
 	assert.Equal(t, "Beautiful, thanks!", messages[2].Content)
 }
@@ -127,9 +127,9 @@ func TestParseTextHistory_CaseInsensitive(t *testing.T) {
 	content := `user: lowercase user
 ASSISTANT: uppercase assistant
 User: mixed case user`
-	
+
 	messages, err := ParseTextHistory(content)
-	
+
 	assert.NoError(t, err)
 	assert.Len(t, messages, 3)
 	assert.Equal(t, "user", messages[0].Role)
@@ -141,11 +141,11 @@ User: mixed case user`
 }
 
 func TestParseTextHistory_NoMatches(t *testing.T) {
-	content := `This is just regular text without conversation patterns.
+	content := `This is just regular content without conversation patterns.
 It should not be parsed as a conversation.`
-	
+
 	messages, err := ParseTextHistory(content)
-	
+
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no conversation messages found")
 	assert.Nil(t, messages)
@@ -153,9 +153,9 @@ It should not be parsed as a conversation.`
 
 func TestParseTextHistory_EmptyInput(t *testing.T) {
 	content := ``
-	
+
 	messages, err := ParseTextHistory(content)
-	
+
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no conversation messages found")
 	assert.Nil(t, messages)
@@ -175,7 +175,7 @@ func TestIsConversationFile(t *testing.T) {
 		{"regular.md", false},
 		{"", false},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.filename, func(t *testing.T) {
 			result := IsConversationFile(tt.filename)

--- a/internal/parser/conversation_test.go
+++ b/internal/parser/conversation_test.go
@@ -1,0 +1,185 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseJSONHistory_Valid(t *testing.T) {
+	content := `[
+		{"role": "user", "content": "Hello"},
+		{"role": "assistant", "content": "Hi there!"},
+		{"role": "user", "content": "How are you?"}
+	]`
+	
+	messages, err := ParseJSONHistory([]byte(content))
+	
+	assert.NoError(t, err)
+	assert.Len(t, messages, 3)
+	assert.Equal(t, "user", messages[0].Role)
+	assert.Equal(t, "Hello", messages[0].Content)
+	assert.Equal(t, "assistant", messages[1].Role)
+	assert.Equal(t, "Hi there!", messages[1].Content)
+	assert.Equal(t, "user", messages[2].Role)
+	assert.Equal(t, "How are you?", messages[2].Content)
+}
+
+func TestParseJSONHistory_InvalidJSON(t *testing.T) {
+	content := `[
+		{"role": "user", "content": "Hello",
+		{"role": "assistant", "content": "Hi there!"}
+	]`
+	
+	messages, err := ParseJSONHistory([]byte(content))
+	
+	assert.Error(t, err)
+	assert.Nil(t, messages)
+}
+
+func TestParseJSONHistory_InvalidRole(t *testing.T) {
+	content := `[
+		{"role": "user", "content": "Hello"},
+		{"role": "invalid", "content": "Bad role"}
+	]`
+	
+	messages, err := ParseJSONHistory([]byte(content))
+	
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role 'invalid'")
+	assert.Nil(t, messages)
+}
+
+func TestParseJSONHistory_EmptyContent(t *testing.T) {
+	content := `[
+		{"role": "user", "content": "Hello"},
+		{"role": "assistant", "content": ""}
+	]`
+	
+	messages, err := ParseJSONHistory([]byte(content))
+	
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty message content")
+	assert.Nil(t, messages)
+}
+
+func TestParseTextHistory_Valid(t *testing.T) {
+	content := `User: What is the capital of France?
+Assistant: The capital of France is Paris.
+User: What about Italy?
+Assistant: The capital of Italy is Rome.`
+	
+	messages, err := ParseTextHistory(content)
+	
+	assert.NoError(t, err)
+	assert.Len(t, messages, 4)
+	assert.Equal(t, "user", messages[0].Role)
+	assert.Equal(t, "What is the capital of France?", messages[0].Content)
+	assert.Equal(t, "assistant", messages[1].Role)
+	assert.Equal(t, "The capital of France is Paris.", messages[1].Content)
+	assert.Equal(t, "user", messages[2].Role)
+	assert.Equal(t, "What about Italy?", messages[2].Content)
+	assert.Equal(t, "assistant", messages[3].Role)
+	assert.Equal(t, "The capital of Italy is Rome.", messages[3].Content)
+}
+
+func TestParseTextHistory_MarkdownFormat(t *testing.T) {
+	content := `**User:** What is 2 + 2?
+**Assistant:** 2 + 2 equals 4.
+**User:** Thanks!`
+	
+	messages, err := ParseTextHistory(content)
+	
+	assert.NoError(t, err)
+	assert.Len(t, messages, 3)
+	assert.Equal(t, "user", messages[0].Role)
+	assert.Equal(t, "What is 2 + 2?", messages[0].Content)
+	assert.Equal(t, "assistant", messages[1].Role)
+	assert.Equal(t, "2 + 2 equals 4.", messages[1].Content)
+	assert.Equal(t, "user", messages[2].Role)
+	assert.Equal(t, "Thanks!", messages[2].Content)
+}
+
+func TestParseTextHistory_MultilineContent(t *testing.T) {
+	content := `User: Can you write a haiku?
+Assistant: Here's a haiku for you:
+
+Code flows like water
+Functions dance in harmony
+Bugs hide in shadows
+
+User: Beautiful, thanks!`
+	
+	messages, err := ParseTextHistory(content)
+	
+	assert.NoError(t, err)
+	assert.Len(t, messages, 3)
+	assert.Equal(t, "user", messages[0].Role)
+	assert.Equal(t, "Can you write a haiku?", messages[0].Content)
+	assert.Equal(t, "assistant", messages[1].Role)
+	assert.Contains(t, messages[1].Content, "Here's a haiku for you:")
+	assert.Contains(t, messages[1].Content, "Code flows like water")
+	assert.Equal(t, "user", messages[2].Role)
+	assert.Equal(t, "Beautiful, thanks!", messages[2].Content)
+}
+
+func TestParseTextHistory_CaseInsensitive(t *testing.T) {
+	content := `user: lowercase user
+ASSISTANT: uppercase assistant
+User: mixed case user`
+	
+	messages, err := ParseTextHistory(content)
+	
+	assert.NoError(t, err)
+	assert.Len(t, messages, 3)
+	assert.Equal(t, "user", messages[0].Role)
+	assert.Equal(t, "lowercase user", messages[0].Content)
+	assert.Equal(t, "assistant", messages[1].Role)
+	assert.Equal(t, "uppercase assistant", messages[1].Content)
+	assert.Equal(t, "user", messages[2].Role)
+	assert.Equal(t, "mixed case user", messages[2].Content)
+}
+
+func TestParseTextHistory_NoMatches(t *testing.T) {
+	content := `This is just regular text without conversation patterns.
+It should not be parsed as a conversation.`
+	
+	messages, err := ParseTextHistory(content)
+	
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no conversation messages found")
+	assert.Nil(t, messages)
+}
+
+func TestParseTextHistory_EmptyInput(t *testing.T) {
+	content := ``
+	
+	messages, err := ParseTextHistory(content)
+	
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no conversation messages found")
+	assert.Nil(t, messages)
+}
+
+func TestIsConversationFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		expected bool
+	}{
+		{"chat.conversation", true},
+		{"history.chat", true},
+		{"log.history", true},
+		{"Chat.CONVERSATION", true}, // case insensitive
+		{"file.txt", false},
+		{"conversation.py", false},
+		{"regular.md", false},
+		{"", false},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			result := IsConversationFile(tt.filename)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces support for structured exit codes in the `slop` application to enhance automation and routing capabilities. It also includes support for conversation-based context items and updates to the documentation.
The most important changes are grouped and summarized below:

### Documentation Updates
- Added a new section in `README.md` explaining structured exit codes (`--sentiment` and `--pass-fail` flags) and their use in shell scripts for branching logic. Examples of sentiment-based and pass/fail routing are provided.

### Application Enhancements
- Introduced the `enhanceSystemPromptForExitCode` function in `internal/app/app.go` to append exit code instructions to system prompts based on the selected mode (e.g., sentiment or pass-fail).
- Updated the `Run` method in `internal/app/app.go` to:
  - Accept an `exitMode` parameter for determining the exit code logic.
  - Return an additional `exitCode` value alongside the response and error.
  - Integrate exit code determination logic for sentiment, pass-fail, and custom modes. [[1]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7L140-R163) [[2]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7L284-R378)
- Enhanced the `buildSyntheticMessageHistory` function to handle processed context results, improving support for conversation-based context items. [[1]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R192-R229) [[2]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7L284-R378)

### Testing Enhancements
- Updated all relevant unit tests in `internal/app/app_test.go` to validate the new `exitCode` behavior. This includes ensuring the correct exit code is returned for various scenarios, such as successful execution, errors, and specific exit modes. [[1]](diffhunk://#diff-5f21c8fa3b9eb8337a5d511c99ca8bbc25ae101d0b1d97ba764ceb45f8cdff35L134-R137) [[2]](diffhunk://#diff-5f21c8fa3b9eb8337a5d511c99ca8bbc25ae101d0b1d97ba764ceb45f8cdff35L577-R589)
- Modified tests for `buildSyntheticMessageHistory` to include the new `contextResult` parameter for enhanced context processing. [[1]](diffhunk://#diff-5f21c8fa3b9eb8337a5d511c99ca8bbc25ae101d0b1d97ba764ceb45f8cdff35L404-R409) [[2]](diffhunk://#diff-5f21c8fa3b9eb8337a5d511c99ca8bbc25ae101d0b1d97ba764ceb45f8cdff35L685-R695)