### PR TITLE
feat: add --thinking flag

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -158,7 +158,7 @@ func getSpinner(providerName, modelName string) (glyphs []string, speed int) {
 }
 
 // Run executes the main application logic
-func (a *App) Run(ctx context.Context, cliArgs []string, contextResult *slopContext.ContextResult, commandContext, providerName, modelName, messageTemplate, exitMode string) (string, int, error) {
+func (a *App) Run(ctx context.Context, cliArgs []string, contextResult *slopContext.ContextResult, commandContext, providerName, modelName, messageTemplate, exitMode string, hideThinking, showThinking bool) (string, int, error) {
 	if a.cfg == nil {
 		return "", 0, fmt.Errorf("configuration is nil")
 	}
@@ -324,8 +324,14 @@ func (a *App) Run(ctx context.Context, cliArgs []string, contextResult *slopCont
 		return "", 0, fmt.Errorf("failed to generate response: %w", err)
 	}
 
+	// apply thinking filter to raw response before format cleaning
+	thinkingFilteredResponse, err := a.applyThinkingFilter(response, hideThinking, showThinking)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to apply thinking filter: %w", err)
+	}
+
 	// clean the response based on format requirements
-	cleanedResponse := cleanFormattedResponse(response, a.cfg.Format)
+	cleanedResponse := cleanFormattedResponse(thinkingFilteredResponse, a.cfg.Format)
 
 	// determine exit code based on exit mode
 	var exitCode int
@@ -406,4 +412,15 @@ func buildSyntheticMessageHistory(input *slopIO.StructuredInput, contextResult *
 	}
 
 	return messages
+}
+
+// applyThinkingFilter applies thinking content filtering based on provided flags
+func (a *App) applyThinkingFilter(response string, hideThinking, showThinking bool) (string, error) {
+	// Apply thinking filter using the format package
+	filteredResponse, err := format.ApplyThinkingFilter(response, hideThinking, showThinking)
+	if err != nil {
+		return "", err
+	}
+
+	return filteredResponse, nil
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -131,7 +131,7 @@ func TestApp_SyntheticMessageHistory_BasicScenario(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "", false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -202,7 +202,7 @@ func TestApp_SyntheticMessageHistory_ContextFiles(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"analyze these files"}, contextResult, "", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"analyze these files"}, contextResult, "", "test-provider", "test-model", "", "", false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -271,7 +271,7 @@ func TestApp_SyntheticMessageHistory_ComplexScenario(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"find security vulnerabilities"}, contextResult, "You are reviewing windmill plans", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"find security vulnerabilities"}, contextResult, "You are reviewing windmill plans", "test-provider", "test-model", "", "", false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -317,7 +317,7 @@ func TestApp_SyntheticMessageHistory_EmptyContextFiles(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"process files"}, contextResult, "", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"process files"}, contextResult, "", "test-provider", "test-model", "", "", false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -386,7 +386,7 @@ func TestApp_SyntheticMessageHistory_ManyContextFiles(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"summarize all files"}, contextResult, "", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"summarize all files"}, contextResult, "", "test-provider", "test-model", "", "", false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -481,7 +481,7 @@ func TestApp_Run_CreateProvider_Error(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "nonexistent", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "nonexistent", "test-model", "", "", false, false)
 
 	assert.Error(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -511,7 +511,7 @@ func TestApp_Run_Generate_Error(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "", false, false)
 
 	assert.Error(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -532,7 +532,7 @@ func TestApp_Run_NoInput_Error(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{}, createEmptyContextResult(), "", "mock", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{}, createEmptyContextResult(), "", "mock", "test-model", "", "", false, false)
 
 	assert.Error(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -544,7 +544,7 @@ func TestApp_Run_NilConfig_Error(t *testing.T) {
 	app := NewApp(nil, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "", false, false)
 
 	assert.Error(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -583,7 +583,7 @@ func TestApp_Run_FormatEnhancement_JSON(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "")
+	result, exitCode, err := app.Run(ctx, []string{"test input"}, createEmptyContextResult(), "", "test-provider", "test-model", "", "", false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -738,7 +738,7 @@ func TestApp_Run_WithMessageTemplate(t *testing.T) {
 	app := NewApp(cfg, slog.Default(), false)
 
 	ctx := context.Background()
-	result, exitCode, err := app.Run(ctx, []string{"function main() {}"}, createEmptyContextResult(), "", "test-provider", "test-model", "Please review: {input}", "")
+	result, exitCode, err := app.Run(ctx, []string{"function main() {}"}, createEmptyContextResult(), "", "test-provider", "test-model", "Please review: {input}", "", false, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -160,6 +160,9 @@ var rootCmd = &cobra.Command{
 			"timeout":        "parameters.timeout",
 			"test":           "test",
 			"exit-code":      "exit_code_map",
+			"hide-thinking":  "hide_thinking",
+			"show-thinking":  "show_thinking",
+			"thinking":       "parameters.thinking",
 		}
 
 		// bind each flag to corresponding Viper key
@@ -243,11 +246,19 @@ func init() {
 	rootCmd.PersistentFlags().Bool("pass-fail", false, "Exit with code 30 (pass) or 31 (fail)")
 	rootCmd.PersistentFlags().String("exit-code", "", "Apply a custom exit code map from your config")
 
+	// thinking (or 'reasoning') output control flags (mutually exclusive)
+	rootCmd.PersistentFlags().Bool("hide-thinking", true, "Hide thinking content from model outputs (default)")
+	rootCmd.PersistentFlags().Bool("show-thinking", false, "Show thinking/reasoning content")
+
+	// thinking/reasoning control (off|medium|high)
+	rootCmd.PersistentFlags().StringP("thinking", "t", "off", "Request model reasoning effort: off|medium|high")
+
 	// mark the mutually exclusive flags
 	rootCmd.MarkFlagsMutuallyExclusive("fast", "deep")
 	rootCmd.MarkFlagsMutuallyExclusive("local", "remote")
 	rootCmd.MarkFlagsMutuallyExclusive("json", "jsonl", "yaml", "md", "xml")
 	rootCmd.MarkFlagsMutuallyExclusive("sentiment", "pass-fail", "exit-code")
+	rootCmd.MarkFlagsMutuallyExclusive("hide-thinking", "show-thinking")
 
 	// list of flags to hide for now
 	flagsToHide := []string{"test", "stream"}
@@ -255,7 +266,7 @@ func init() {
 	for _, flagName := range flagsToHide {
 		err := rootCmd.PersistentFlags().MarkHidden(flagName)
 		if err != nil {
-			// this shouldn't happen in production, but it's good practice to catch? ¯\_(ツ)_/¯
+			// this shouldn't happen in production, but it's good practice to catch?
 			panic(err)
 		}
 	}
@@ -304,6 +315,22 @@ func executeApp(cmd *cobra.Command, args []string, cfg *config.Config, contextRe
 		return fmt.Errorf("failed to get verbose flag: %w", err)
 	}
 
+	// get thinking filter flags
+	hideThinking, err := cmd.Flags().GetBool("hide-thinking")
+	if err != nil {
+		return fmt.Errorf("failed to get hide-thinking flag: %w", err)
+	}
+	showThinking, err := cmd.Flags().GetBool("show-thinking")
+	if err != nil {
+		return fmt.Errorf("failed to get show-thinking flag: %w", err)
+	}
+
+	// handle mutual exclusivity with default values
+	// if show-thinking is explicitly set, override hide-thinking's default
+	if cmd.Flags().Changed("show-thinking") && showThinking {
+		hideThinking = false
+	}
+
 	// show command usage information if requested
 	if showCommandInfo {
 		if cmdConfig, exists := cfg.Commands[commandName]; exists {
@@ -324,6 +351,8 @@ func executeApp(cmd *cobra.Command, args []string, cfg *config.Config, contextRe
 		modelName,
 		messageTemplate,
 		exitMode,
+		hideThinking,
+		showThinking,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to run app: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,10 +152,27 @@ func (m *Manager) Load(configPath string) error {
 		return fmt.Errorf("invalid command configuration: %w", err)
 	}
 
+	// validate thinking enum — reject unknown values at load time with a
+	// clear message rather than at request time
+	if err := m.validateThinking(); err != nil {
+		return err
+	}
+
 	// post-process configuration to handle special cases
 	m.postProcessConfig()
 
 	return nil
+}
+
+// validateThinking rejects unknown values for parameters.thinking so the
+// user sees a clear error at load time instead of a silent no-op later.
+func (m *Manager) validateThinking() error {
+	switch m.cfg.Parameters.Thinking {
+	case "", "off", "medium", "high":
+		return nil
+	default:
+		return fmt.Errorf("invalid parameters.thinking %q: expected off|medium|high", m.cfg.Parameters.Thinking)
+	}
 }
 
 // config returns the current configuration

--- a/internal/config/data/default_config.toml
+++ b/internal/config/data/default_config.toml
@@ -8,6 +8,7 @@ system_prompt = """You are a helpful and concise command-line assistant, slop.
 Provide direct answers without any preamble, conversational filler, or apologies"""
 default_model_type = "fast"
 default_location = "remote"
+thinking = "off"
 timeout = 30
 max_retries = 1
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -25,6 +25,10 @@ type Parameters struct {
 	DefaultModelType string `mapstructure:"default_model_type"` // "fast" or "deep"
 	DefaultLocation  string `mapstructure:"default_location"`   // "local" or "remote"
 
+	// thinking / reasoning effort — "off", "medium", or "high".
+	// translated by each provider adapter into its upstream native parameter.
+	Thinking string `mapstructure:"thinking"`
+
 	// application behavior
 	Timeout    int `mapstructure:"timeout"`
 	MaxRetries int `mapstructure:"max_retries"`

--- a/internal/format/thinking.go
+++ b/internal/format/thinking.go
@@ -1,0 +1,312 @@
+package format
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ModelType represents the detected model type for thinking content filtering
+type ModelType int
+
+const (
+	ModelUnknown ModelType = iota
+	ModelGPTOss
+	ModelDeepSeekR1JSON
+	ModelDeepSeekR1CLI
+)
+
+// FilterResult contains the results of thinking content filtering
+type FilterResult struct {
+	ThinkingContent string
+	FinalContent    string
+	ModelType       ModelType
+	HasThinking     bool
+}
+
+// ThinkingFilter handles detection and filtering of thinking content from various model outputs
+type ThinkingFilter struct {
+	hideThinking bool
+	showThinking bool
+	patterns     map[string]*regexp.Regexp
+}
+
+// NewThinkingFilter creates a new ThinkingFilter instance with pre-compiled regex patterns
+func NewThinkingFilter(hideThinking, showThinking bool) *ThinkingFilter {
+	// pre-compile regex patterns for performance
+	patterns := map[string]*regexp.Regexp{
+		// GPT-OSS harmony format patterns
+		"gpt_oss_analysis": regexp.MustCompile(`(?s)<\|start\|>assistant<\|channel\|>analysis<\|message\|>(.*?)<\|end\|>`),
+		"gpt_oss_final":    regexp.MustCompile(`(?s)<\|channel\|>final<\|message\|>(.*?)(?:<\|end\|>|$)`),
+		"harmony_cleanup":  regexp.MustCompile(`<\|[^|]*\|>`),
+
+		// DeepSeek R1 CLI patterns
+		"deepseek_think_tags":   regexp.MustCompile(`(?s)<think>(.*?)</think>`),
+		"deepseek_thinking_dot": regexp.MustCompile(`(?s)Thinking\.\.\.(.*?)(?:\n\n|$)`),
+
+		// general cleanup patterns
+		"extra_whitespace": regexp.MustCompile(`\n{3,}`),
+	}
+
+	return &ThinkingFilter{
+		hideThinking: hideThinking,
+		showThinking: showThinking,
+		patterns:     patterns,
+	}
+}
+
+// DetectModelType analyzes content to determine the model type and thinking format
+func (tf *ThinkingFilter) DetectModelType(content string) ModelType {
+	// check for GPT-OSS harmony format
+	if tf.patterns["gpt_oss_analysis"].MatchString(content) {
+		return ModelGPTOss
+	}
+
+	// check for DeepSeek R1 JSON format
+	if tf.isDeepSeekJSON(content) {
+		return ModelDeepSeekR1JSON
+	}
+
+	// check for DeepSeek R1 CLI formats
+	if tf.patterns["deepseek_think_tags"].MatchString(content) ||
+		tf.patterns["deepseek_thinking_dot"].MatchString(content) {
+		return ModelDeepSeekR1CLI
+	}
+
+	return ModelUnknown
+}
+
+// isDeepSeekJSON checks if content is DeepSeek R1 JSON format with thinking field
+func (tf *ThinkingFilter) isDeepSeekJSON(content string) bool {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		return false
+	}
+
+	// check for thinking and content fields
+	_, hasThinking := parsed["thinking"]
+	_, hasContent := parsed["content"]
+	return hasThinking && hasContent
+}
+
+// FilterContent processes content based on detected model type and returns filtered result
+func (tf *ThinkingFilter) FilterContent(content string) (*FilterResult, error) {
+	modelType := tf.DetectModelType(content)
+
+	var result *FilterResult
+	var err error
+
+	switch modelType {
+	case ModelGPTOss:
+		result, err = tf.filterGPTOss(content)
+	case ModelDeepSeekR1JSON:
+		result, err = tf.filterDeepSeekJSON(content)
+	case ModelDeepSeekR1CLI:
+		result, err = tf.filterDeepSeekCLI(content)
+	default:
+		// No thinking content detected, return original content
+		result = &FilterResult{
+			ThinkingContent: "",
+			FinalContent:    content,
+			ModelType:       ModelUnknown,
+			HasThinking:     false,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	result.ModelType = modelType
+	return result, nil
+}
+
+// filterGPTOss handles GPT-OSS harmony format filtering
+func (tf *ThinkingFilter) filterGPTOss(content string) (*FilterResult, error) {
+	// extract thinking content from analysis sections using submatch to get capture group
+	analysisMatches := tf.patterns["gpt_oss_analysis"].FindAllStringSubmatch(content, -1)
+	var thinkingParts []string
+	for _, match := range analysisMatches {
+		if len(match) > 1 {
+			thinking := strings.TrimSpace(match[1]) // match[1] is the captured group
+			if thinking != "" {
+				thinkingParts = append(thinkingParts, thinking)
+			}
+		}
+	}
+
+	// extract final content
+	finalMatches := tf.patterns["gpt_oss_final"].FindStringSubmatch(content)
+	var finalContent string
+	if len(finalMatches) > 1 {
+		finalContent = strings.TrimSpace(finalMatches[1])
+	} else {
+		// as a fallback, remove analysis sections. clean up.
+		finalContent = tf.patterns["gpt_oss_analysis"].ReplaceAllString(content, "")
+		finalContent = tf.patterns["harmony_cleanup"].ReplaceAllString(finalContent, "")
+		finalContent = strings.TrimSpace(finalContent)
+	}
+
+	return &FilterResult{
+		ThinkingContent: strings.Join(thinkingParts, "\n\n"),
+		FinalContent:    finalContent,
+		HasThinking:     len(thinkingParts) > 0,
+	}, nil
+}
+
+// filterDeepSeekJSON handles DeepSeek R1 JSON format filtering
+func (tf *ThinkingFilter) filterDeepSeekJSON(content string) (*FilterResult, error) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse DeepSeek JSON: %w", err)
+	}
+
+	thinking, _ := parsed["thinking"].(string)
+	finalContent, _ := parsed["content"].(string)
+
+	return &FilterResult{
+		ThinkingContent: thinking,
+		FinalContent:    finalContent,
+		HasThinking:     thinking != "",
+	}, nil
+}
+
+// filterDeepSeekCLI handles DeepSeek R1 CLI format filtering.
+// It extracts <think>...</think> blocks and handles any
+// remaining "Thinking..." prefix sections
+func (tf *ThinkingFilter) filterDeepSeekCLI(content string) (*FilterResult, error) {
+	remaining, tagThinking := extractThinkTags(content)
+
+	remaining, prefixThinking := extractThinkingPrefix(remaining)
+
+	thinkingParts := make([]string, 0, len(tagThinking)+len(prefixThinking))
+	thinkingParts = append(thinkingParts, tagThinking...)
+	thinkingParts = append(thinkingParts, prefixThinking...)
+
+	// collapse 3+ newlines to 2 and strip outer whitespace
+	remaining = tf.patterns["extra_whitespace"].ReplaceAllString(remaining, "\n\n")
+	remaining = strings.TrimSpace(remaining)
+
+	return &FilterResult{
+		ThinkingContent: strings.Join(thinkingParts, "\n\n"),
+		FinalContent:    remaining,
+		HasThinking:     len(thinkingParts) > 0,
+	}, nil
+}
+
+// extractThinkTags scans for <think>...</think> blocks w/ nesting awareness
+func extractThinkTags(content string) (stripped string, thinking []string) {
+	const openTag = "<think>"
+	const closeTag = "</think>"
+
+	var remaining strings.Builder
+	var current strings.Builder
+	depth := 0
+
+	i := 0
+	for i < len(content) {
+		if strings.HasPrefix(content[i:], openTag) {
+			depth++
+			if depth > 1 {
+				current.WriteString(openTag)
+			}
+			i += len(openTag)
+			continue
+		}
+		if strings.HasPrefix(content[i:], closeTag) {
+			if depth == 0 {
+				// stray close tag — treat as literal
+				remaining.WriteString(closeTag)
+				i += len(closeTag)
+				continue
+			}
+			depth--
+			if depth == 0 {
+				thought := strings.TrimSpace(current.String())
+				if thought != "" {
+					thinking = append(thinking, thought)
+				}
+				current.Reset()
+			} else {
+				current.WriteString(closeTag)
+			}
+			i += len(closeTag)
+			continue
+		}
+
+		if depth > 0 {
+			current.WriteByte(content[i])
+		} else {
+			remaining.WriteByte(content[i])
+		}
+		i++
+	}
+
+	// unclosed outer tag — restore what we captured so the content isn't lost
+	if depth > 0 {
+		remaining.WriteString(openTag)
+		remaining.WriteString(current.String())
+	}
+
+	return remaining.String(), thinking
+}
+
+// extractThinkingPrefix finds "Thinking..." markers in content
+// final answer is whatever remains after all thinking blocks removed
+func extractThinkingPrefix(content string) (stripped string, thinking []string) {
+	const marker = "Thinking..."
+	for {
+		idx := strings.Index(content, marker)
+		if idx < 0 {
+			break
+		}
+		before := content[:idx]
+		after := content[idx+len(marker):]
+
+		end := strings.Index(after, "\n\n")
+		if end < 0 {
+			thought := strings.TrimSpace(after)
+			if thought != "" {
+				thinking = append(thinking, thought)
+			}
+			content = before
+			break
+		}
+
+		thought := strings.TrimSpace(after[:end])
+		if thought != "" {
+			thinking = append(thinking, thought)
+		}
+		content = before + after[end+2:]
+	}
+	return content, thinking
+}
+
+// FormatOutput formats the final output based on thinking filter settings
+func (tf *ThinkingFilter) FormatOutput(result *FilterResult) string {
+	// if no thinking content (or hide-thinking is true) return only final content
+	if !result.HasThinking || tf.hideThinking {
+		return result.FinalContent
+	}
+
+	// if show-thinking is true and we have thinking content, format...
+	if tf.showThinking && result.HasThinking {
+		return fmt.Sprintf("Thinking:\n%s\n\nResponse:\n%s", result.ThinkingContent, result.FinalContent)
+	}
+
+	// as fallback/default, return final content only
+	return result.FinalContent
+}
+
+// ApplyThinkingFilter is the main entry point for thinking content filtering.
+func ApplyThinkingFilter(content string, hideThinking, showThinking bool) (string, error) {
+	filter := NewThinkingFilter(hideThinking, showThinking)
+
+	result, err := filter.FilterContent(content)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(filter.FormatOutput(result)), nil
+}

--- a/internal/format/thinking_test.go
+++ b/internal/format/thinking_test.go
@@ -1,0 +1,472 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThinkingFilter_DetectModelType(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected ModelType
+	}{
+		{
+			name:     "GPT-OSS harmony format",
+			content:  `<|start|>assistant<|channel|>analysis<|message|>This is analysis<|end|><|channel|>final<|message|>Final answer`,
+			expected: ModelGPTOss,
+		},
+		{
+			name:     "DeepSeek R1 JSON format",
+			content:  `{"thinking": "I need to think about this", "content": "Here is my answer"}`,
+			expected: ModelDeepSeekR1JSON,
+		},
+		{
+			name:     "DeepSeek R1 CLI with think tags",
+			content:  "<think>Let me consider this problem</think>\nHere is the answer",
+			expected: ModelDeepSeekR1CLI,
+		},
+		{
+			name:     "DeepSeek R1 CLI with Thinking prefix",
+			content:  "Thinking...\nThis is a complex problem\n\nThe answer is 42",
+			expected: ModelDeepSeekR1CLI,
+		},
+		{
+			name:     "No thinking content",
+			content:  `This is just a regular response with no thinking markers`,
+			expected: ModelUnknown,
+		},
+		{
+			name:     "Invalid JSON",
+			content:  `{"thinking": invalid json}`,
+			expected: ModelUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := NewThinkingFilter(false, false)
+			result := filter.DetectModelType(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestThinkingFilter_FilterGPTOss(t *testing.T) {
+	tests := []struct {
+		name                string
+		content             string
+		expectedThinking    string
+		expectedFinal       string
+		expectedHasThinking bool
+	}{
+		{
+			name:                "Standard GPT-OSS format",
+			content:             `<|start|>assistant<|channel|>analysis<|message|>I need to analyze this carefully<|end|><|channel|>final<|message|>The answer is 42<|end|>`,
+			expectedThinking:    "I need to analyze this carefully",
+			expectedFinal:       "The answer is 42",
+			expectedHasThinking: true,
+		},
+		{
+			name:                "Multiple analysis sections",
+			content:             `<|start|>assistant<|channel|>analysis<|message|>First thought<|end|><|start|>assistant<|channel|>analysis<|message|>Second thought<|end|><|channel|>final<|message|>Final answer<|end|>`,
+			expectedThinking:    "First thought\n\nSecond thought",
+			expectedFinal:       "Final answer",
+			expectedHasThinking: true,
+		},
+		{
+			name:                "No final section",
+			content:             `<|start|>assistant<|channel|>analysis<|message|>Just thinking<|end|>Some other content`,
+			expectedThinking:    "Just thinking",
+			expectedFinal:       "Some other content", // fallback behavior
+			expectedHasThinking: true,
+		},
+		{
+			name:                "No analysis section",
+			content:             `<|channel|>final<|message|>Just the answer<|end|>`,
+			expectedThinking:    "",
+			expectedFinal:       "Just the answer",
+			expectedHasThinking: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := NewThinkingFilter(false, false)
+			result, err := filter.filterGPTOss(tt.content)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedThinking, result.ThinkingContent)
+			assert.Equal(t, tt.expectedFinal, result.FinalContent)
+			assert.Equal(t, tt.expectedHasThinking, result.HasThinking)
+		})
+	}
+}
+
+func TestThinkingFilter_FilterDeepSeekJSON(t *testing.T) {
+	tests := []struct {
+		name                string
+		content             string
+		expectedThinking    string
+		expectedFinal       string
+		expectedHasThinking bool
+		expectError         bool
+	}{
+		{
+			name:                "Valid JSON with thinking",
+			content:             `{"thinking": "Let me think about this step by step", "content": "The answer is 42"}`,
+			expectedThinking:    "Let me think about this step by step",
+			expectedFinal:       "The answer is 42",
+			expectedHasThinking: true,
+			expectError:         false,
+		},
+		{
+			name:                "Valid JSON without thinking",
+			content:             `{"content": "Just the answer"}`,
+			expectedThinking:    "",
+			expectedFinal:       "Just the answer",
+			expectedHasThinking: false,
+			expectError:         false,
+		},
+		{
+			name:                "Invalid JSON",
+			content:             `{"thinking": invalid}`,
+			expectedThinking:    "",
+			expectedFinal:       "",
+			expectedHasThinking: false,
+			expectError:         true,
+		},
+		{
+			name:                "Empty thinking field",
+			content:             `{"thinking": "", "content": "The answer"}`,
+			expectedThinking:    "",
+			expectedFinal:       "The answer",
+			expectedHasThinking: false,
+			expectError:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := NewThinkingFilter(false, false)
+			result, err := filter.filterDeepSeekJSON(tt.content)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedThinking, result.ThinkingContent)
+				assert.Equal(t, tt.expectedFinal, result.FinalContent)
+				assert.Equal(t, tt.expectedHasThinking, result.HasThinking)
+			}
+		})
+	}
+}
+
+func TestThinkingFilter_FilterDeepSeekCLI(t *testing.T) {
+	tests := []struct {
+		name                string
+		content             string
+		expectedThinking    string
+		expectedFinal       string
+		expectedHasThinking bool
+	}{
+		{
+			name:                "Think tags",
+			content:             "<think>I need to solve this problem</think>\nThe answer is 42",
+			expectedThinking:    "I need to solve this problem",
+			expectedFinal:       "The answer is 42",
+			expectedHasThinking: true,
+		},
+		{
+			name:                "Multiple think tags",
+			content:             "<think>First thought</think>Some text<think>Second thought</think>\nFinal answer",
+			expectedThinking:    "First thought\n\nSecond thought",
+			expectedFinal:       "Some text\nFinal answer",
+			expectedHasThinking: true,
+		},
+		{
+			name:                "Thinking prefix",
+			content:             "Thinking...\nThis is complex\n\nThe answer is 42",
+			expectedThinking:    "This is complex",
+			expectedFinal:       "The answer is 42",
+			expectedHasThinking: true,
+		},
+		{
+			name:                "Mixed formats",
+			content:             "<think>Tag thinking</think>\nThinking...\nPrefix thinking\n\nFinal answer here",
+			expectedThinking:    "Tag thinking\n\nPrefix thinking",
+			expectedFinal:       "Final answer here",
+			expectedHasThinking: true,
+		},
+		{
+			name:                "Leading newlines in think tag",
+			content:             "<think>\n\nBoxer should work harder\n</think>\nFour legs good, two legs bad.",
+			expectedThinking:    "Boxer should work harder",
+			expectedFinal:       "Four legs good, two legs bad.",
+			expectedHasThinking: true,
+		},
+		{
+			name:                "No thinking content",
+			content:             `Just a regular response`,
+			expectedThinking:    "",
+			expectedFinal:       "Just a regular response",
+			expectedHasThinking: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := NewThinkingFilter(false, false)
+			result, err := filter.filterDeepSeekCLI(tt.content)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedThinking, result.ThinkingContent)
+			assert.Equal(t, tt.expectedFinal, result.FinalContent)
+			assert.Equal(t, tt.expectedHasThinking, result.HasThinking)
+		})
+	}
+}
+
+func TestThinkingFilter_FormatOutput(t *testing.T) {
+	tests := []struct {
+		name           string
+		hideThinking   bool
+		showThinking   bool
+		result         *FilterResult
+		expectedOutput string
+	}{
+		{
+			name:         "Hide thinking - default behavior",
+			hideThinking: true,
+			showThinking: false,
+			result: &FilterResult{
+				ThinkingContent: "Some thinking",
+				FinalContent:    "Final answer",
+				HasThinking:     true,
+			},
+			expectedOutput: "Final answer",
+		},
+		{
+			name:         "Show thinking - formatted output",
+			hideThinking: false,
+			showThinking: true,
+			result: &FilterResult{
+				ThinkingContent: "Complex reasoning here",
+				FinalContent:    "The answer is 42",
+				HasThinking:     true,
+			},
+			expectedOutput: "Thinking:\nComplex reasoning here\n\nResponse:\nThe answer is 42",
+		},
+		{
+			name:         "No thinking content",
+			hideThinking: false,
+			showThinking: true,
+			result: &FilterResult{
+				ThinkingContent: "",
+				FinalContent:    "Just the answer",
+				HasThinking:     false,
+			},
+			expectedOutput: "Just the answer",
+		},
+		{
+			name:         "Both flags false - default to hide",
+			hideThinking: false,
+			showThinking: false,
+			result: &FilterResult{
+				ThinkingContent: "Some thinking",
+				FinalContent:    "Final answer",
+				HasThinking:     true,
+			},
+			expectedOutput: "Final answer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := NewThinkingFilter(tt.hideThinking, tt.showThinking)
+			output := filter.FormatOutput(tt.result)
+			assert.Equal(t, tt.expectedOutput, output)
+		})
+	}
+}
+
+func TestApplyThinkingFilter(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		hideThinking bool
+		showThinking bool
+		expected     string
+	}{
+		{
+			name:         "GPT-OSS content with hide thinking",
+			content:      `<|start|>assistant<|channel|>analysis<|message|>Analysis here<|end|><|channel|>final<|message|>Final answer<|end|>`,
+			hideThinking: true,
+			showThinking: false,
+			expected:     "Final answer",
+		},
+		{
+			name:         "GPT-OSS content with show thinking",
+			content:      `<|start|>assistant<|channel|>analysis<|message|>Analysis here<|end|><|channel|>final<|message|>Final answer<|end|>`,
+			hideThinking: false,
+			showThinking: true,
+			expected:     "Thinking:\nAnalysis here\n\nResponse:\nFinal answer",
+		},
+		{
+			name:         "DeepSeek JSON with hide thinking",
+			content:      `{"thinking": "Step by step reasoning", "content": "The result is 42"}`,
+			hideThinking: true,
+			showThinking: false,
+			expected:     "The result is 42",
+		},
+		{
+			name:         "DeepSeek CLI with show thinking",
+			content:      "<think>Need to consider this</think>\nAnswer: 42",
+			hideThinking: false,
+			showThinking: true,
+			expected:     "Thinking:\nNeed to consider this\n\nResponse:\nAnswer: 42",
+		},
+		{
+			name:         "No thinking content",
+			content:      "Just a regular response",
+			hideThinking: true,
+			showThinking: false,
+			expected:     "Just a regular response",
+		},
+		{
+			name:         "Complex DeepSeek with thinking prefix",
+			content:      "Thinking...\nThis requires careful analysis\n\nBased on my analysis, the answer is 42",
+			hideThinking: false,
+			showThinking: true,
+			expected:     "Thinking:\nThis requires careful analysis\n\nResponse:\nBased on my analysis, the answer is 42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ApplyThinkingFilter(tt.content, tt.hideThinking, tt.showThinking)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestThinkingFilter_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		hideThinking bool
+		showThinking bool
+		expected     string
+	}{
+		{
+			name:         "Empty content",
+			content:      "",
+			hideThinking: true,
+			showThinking: false,
+			expected:     "",
+		},
+		{
+			name:         "Whitespace only",
+			content:      "   \n\t  ",
+			hideThinking: true,
+			showThinking: false,
+			expected:     "",
+		},
+		{
+			name:         "Malformed think tags",
+			content:      "<think>Unclosed thinking",
+			hideThinking: true,
+			showThinking: false,
+			expected:     "<think>Unclosed thinking",
+		},
+		{
+			name:         "Nested think tags",
+			content:      "<think>Outer<think>Inner</think>More outer</think>Final",
+			hideThinking: true,
+			showThinking: false,
+			expected:     "Final",
+		},
+		{
+			name:         "Multiple thinking prefixes",
+			content:      "Thinking...\nFirst thought\n\nThinking...\nSecond thought\n\nFinal answer",
+			hideThinking: false,
+			showThinking: true,
+			expected:     "Thinking:\nFirst thought\n\nSecond thought\n\nResponse:\nFinal answer",
+		},
+		{
+			name:         "Very long thinking content",
+			content:      "<think>" + generateLongString(1000) + "</think>\nShort answer",
+			hideThinking: true,
+			showThinking: false,
+			expected:     "Short answer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ApplyThinkingFilter(tt.content, tt.hideThinking, tt.showThinking)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// generateLongString creates a string of specified length for testing
+func generateLongString(length int) string {
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = 'a' + byte(i%26)
+	}
+	return string(result)
+}
+
+func TestThinkingFilter_RegexPatterns(t *testing.T) {
+	// Test that all regex patterns compile correctly
+	t.Run("All patterns compile", func(t *testing.T) {
+		filter := NewThinkingFilter(false, false)
+
+		// Test that we have all expected patterns
+		expectedPatterns := []string{
+			"gpt_oss_analysis",
+			"gpt_oss_final",
+			"harmony_cleanup",
+			"deepseek_think_tags",
+			"deepseek_thinking_dot",
+			"extra_whitespace",
+		}
+
+		for _, pattern := range expectedPatterns {
+			assert.Contains(t, filter.patterns, pattern, "Pattern %s should exist", pattern)
+			assert.NotNil(t, filter.patterns[pattern], "Pattern %s should be compiled", pattern)
+		}
+	})
+
+	// Test specific pattern behaviors
+	t.Run("GPT-OSS analysis pattern", func(t *testing.T) {
+		filter := NewThinkingFilter(false, false)
+		pattern := filter.patterns["gpt_oss_analysis"]
+
+		// Should match
+		assert.True(t, pattern.MatchString(`<|start|>assistant<|channel|>analysis<|message|>content<|end|>`))
+
+		// Should not match
+		assert.False(t, pattern.MatchString(`<|start|>user<|channel|>analysis<|message|>content<|end|>`))
+		assert.False(t, pattern.MatchString(`<|start|>assistant<|channel|>final<|message|>content<|end|>`))
+	})
+
+	t.Run("DeepSeek think tags pattern", func(t *testing.T) {
+		filter := NewThinkingFilter(false, false)
+		pattern := filter.patterns["deepseek_think_tags"]
+
+		// Should match
+		assert.True(t, pattern.MatchString(`<think>content</think>`))
+		assert.True(t, pattern.MatchString(`prefix<think>multi\nline\ncontent</think>suffix`))
+
+		// Should not match
+		assert.False(t, pattern.MatchString(`<think>unclosed`))
+		assert.False(t, pattern.MatchString(`closed</think>`))
+	})
+}

--- a/internal/llm/common/generation.go
+++ b/internal/llm/common/generation.go
@@ -1,5 +1,7 @@
 package common
 
+import "fmt"
+
 // GenerateOptions contains near-universal generation parameters
 // this follows the interface segregation principle; providers only see relevant options
 type GenerateOptions struct {
@@ -15,6 +17,39 @@ type GenerateOptions struct {
 	// function calling - expect to become standard across providers
 	Tools      []ToolConfig // available tools/functions
 	ToolChoice interface{}  // tool selection strategy
+
+	// Thinking / reasoning effort — translated by each provider adapter into
+	// its upstream native parameter
+	Thinking ThinkingLevel
+}
+
+// ThinkingLevel expresses how much reasoning the model should do. Adapters
+// translate this into their provider-specific native parameter.
+type ThinkingLevel int
+
+const (
+	// ThinkingOff sends no thinking hint and model behaves as normal
+	ThinkingOff ThinkingLevel = iota
+	// ThinkingMedium asks the model for moderate reasoning effort
+	ThinkingMedium
+	// ThinkingHigh asks the model for maximum reasoning effort
+	ThinkingHigh
+)
+
+// ParseThinkingLevel converts a string (e.g. from config or a flag) into a
+// ThinkingLevel. Unknown values return an error so callers can surface a
+// clear message at config-load time rather than at request time
+func ParseThinkingLevel(s string) (ThinkingLevel, error) {
+	switch s {
+	case "", "off":
+		return ThinkingOff, nil
+	case "medium":
+		return ThinkingMedium, nil
+	case "high":
+		return ThinkingHigh, nil
+	default:
+		return ThinkingOff, fmt.Errorf("invalid thinking level %q: expected off|medium|high", s)
+	}
 }
 
 // ToolConfig represents a tool/function definition for function calling
@@ -84,6 +119,15 @@ func WithResponseFormat(format *ResponseFormat) GenerateOption {
 func WithJSONFormat() GenerateOption {
 	return func(c *GenerateOptions) {
 		c.ResponseFormat = &ResponseFormat{Type: "json_object"}
+	}
+}
+
+// WithThinking sets the requested reasoning effort. Adapters translate this
+// into their provider-specific native parameter
+// If provider/model doesn't support, silently no-op/ignore the request
+func WithThinking(level ThinkingLevel) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.Thinking = level
 	}
 }
 

--- a/internal/llm/common/types.go
+++ b/internal/llm/common/types.go
@@ -17,10 +17,12 @@ type Choice struct {
 	FinishReason string  `json:"finish_reason"`
 }
 
-// Message represents a message in a conversation
+// Message represents a message in a conversation.
+// note: thinking carries reasoning traces (separate from content)
 type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role     string `json:"role"`
+	Content  string `json:"content"`
+	Thinking string `json:"thinking,omitempty"`
 }
 
 // Usage represents token usage information

--- a/internal/llm/ollama/client.go
+++ b/internal/llm/ollama/client.go
@@ -13,6 +13,10 @@ type ChatRequest struct {
 
 	// Structured output support
 	Format string `json:"format,omitempty"`
+
+	// Think enables Ollama's native thinking mode for reasoning models
+	// this is pointer so unset (nil) omits the field (rather than sending false)
+	Think *bool `json:"think,omitempty"`
 }
 
 // ChatResponse represents the response from Ollama's chat API

--- a/internal/llm/ollama/options.go
+++ b/internal/llm/ollama/options.go
@@ -10,6 +10,7 @@ type GenerateOptions struct {
 	TopK          *int     // Limits token selection to top K candidates
 	RepeatPenalty *float64 // Penalty for repeating tokens (default: 1.1)
 	Seed          *int     // Random seed for deterministic generation
+	Think         *bool    // native think flag for structured reasoning
 }
 
 // GenerateOption configures Ollama-specific generation parameters
@@ -44,6 +45,15 @@ func WithRepeatPenalty(penalty float64) GenerateOption {
 func WithSeed(seed int) GenerateOption {
 	return func(c *GenerateOptions) {
 		c.Seed = &seed
+	}
+}
+
+// WithThink sets Ollama's native think flag. When modern models
+// return thinking content in a separate message.thinking field
+// the adapter routes to Message.Thinking
+func WithThink(think bool) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.Think = &think
 	}
 }
 

--- a/internal/llm/ollama/provider.go
+++ b/internal/llm/ollama/provider.go
@@ -74,6 +74,13 @@ func (p *Provider) BuildOptions(cfg *config.Config) []interface{} {
 		functionalOpts = append(functionalOpts, WithJSONFormat())
 	}
 
+	// translate the cross-provider thinking level into Ollama's native
+	// think flag. Silent no-op for ThinkingOff and unknown values, so a
+	// user's config default survives switching to a non-thinking model.
+	if level, err := common.ParseThinkingLevel(cfg.Parameters.Thinking); err == nil && level != common.ThinkingOff {
+		functionalOpts = append(functionalOpts, WithThink(true))
+	}
+
 	return []interface{}{NewGenerateOptions(functionalOpts...)}
 }
 
@@ -149,6 +156,11 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		requestBody.Format = "json"
 	}
 
+	// wire the native think flag through to the API
+	if config.Think != nil {
+		requestBody.Think = config.Think
+	}
+
 	return requestBody, nil
 }
 
@@ -178,7 +190,15 @@ func (p *Provider) ParseResponse(body []byte, logger *slog.Logger) (string, *com
 
 	content := chatResp.Message.Content
 
-	// return content and usage information
+	// Ollama returns structured thinking in a separate message.thinking
+	// field when think=true. Re-inline it as a <think> tag so the
+	// downstream format.ApplyThinkingFilter treats structured and
+	// inline-tag thinking identically. Anthropic's content-block thinking
+	// will take the same path in a later branch.
+	if chatResp.Message.Thinking != "" {
+		content = "<think>" + chatResp.Message.Thinking + "</think>\n" + content
+	}
+
 	return content, usage, nil
 }
 

--- a/internal/llm/ollama/provider_test.go
+++ b/internal/llm/ollama/provider_test.go
@@ -342,3 +342,88 @@ func TestProviderInterface(t *testing.T) {
 		assert.Equal(t, "/api/chat", req.URL.Path)
 	})
 }
+
+// TestBuildOptions_Thinking verifies the cross-provider thinking level
+// translates into Ollama's native think flag
+func TestBuildOptions_Thinking(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name      string
+		level     string
+		wantThink *bool
+	}{
+		{name: "off is omitted", level: "off", wantThink: nil},
+		{name: "empty is omitted", level: "", wantThink: nil},
+		{name: "medium sets true", level: "medium", wantThink: boolPtr(true)},
+		{name: "high sets true", level: "high", wantThink: boolPtr(true)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Parameters: config.Parameters{Thinking: tt.level},
+			}
+			opts := provider.BuildOptions(cfg)
+			require := assert.New(t)
+			require.Len(opts, 1)
+			ollamaOpts, ok := opts[0].(*GenerateOptions)
+			require.True(ok)
+
+			if tt.wantThink == nil {
+				require.Nil(ollamaOpts.Think)
+			} else {
+				require.NotNil(ollamaOpts.Think)
+				require.Equal(*tt.wantThink, *ollamaOpts.Think)
+			}
+		})
+	}
+}
+
+// TestParseResponse_StructuredThinking confirms that Ollama's native
+// message.thinking is re-inlined as a <think> tag
+func TestParseResponse_StructuredThinking(t *testing.T) {
+	provider := New()
+	body := []byte(`{
+		"model": "gemma4:latest",
+		"done": true,
+		"message": {
+			"role": "assistant",
+			"content": "Four legs good, two legs bad.",
+			"thinking": "Boxer should work harder on the windmill."
+		},
+		"prompt_eval_count": 10,
+		"eval_count": 20
+	}`)
+
+	content, usage, err := provider.ParseResponse(body, slog.Default())
+	assert.NoError(t, err)
+	assert.NotNil(t, usage)
+	assert.Equal(t, 30, usage.TotalTokens)
+	assert.Equal(t,
+		"<think>Boxer should work harder on the windmill.</think>\nFour legs good, two legs bad.",
+		content,
+	)
+}
+
+// TestParseResponse_NoThinking confirms that when message.thinking is
+// empty, the response content passes through untouched.
+func TestParseResponse_NoThinking(t *testing.T) {
+	provider := New()
+	body := []byte(`{
+		"model": "gemma4:latest",
+		"done": true,
+		"message": {
+			"role": "assistant",
+			"content": "Four legs good, two legs bad."
+		}
+	}`)
+
+	content, _, err := provider.ParseResponse(body, slog.Default())
+	assert.NoError(t, err)
+	assert.Equal(t, "Four legs good, two legs bad.", content)
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
## Summary

- Introduces `--thinking off|medium|high` (`-t`) as a cross-provider reasoning-effort primitive, plumbed through `common.GenerateOptions` as `ThinkingLevel` and `WithThinking`.
- `ThinkingLevel` as foundational primitive that can adapt to model/providers' params
 - Adds `Thinking string` field on `common.Message` and validates `parameters.thinking` at config-load time.