### PR TITLE
feat: add schema-bearing ResponseFormat

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -163,6 +163,7 @@ var rootCmd = &cobra.Command{
 			"hide-thinking":  "hide_thinking",
 			"show-thinking":  "show_thinking",
 			"thinking":       "parameters.thinking",
+			"schema":         "parameters.response_schema",
 		}
 
 		// bind each flag to corresponding Viper key
@@ -252,6 +253,9 @@ func init() {
 
 	// thinking/reasoning control (off|medium|high)
 	rootCmd.PersistentFlags().StringP("thinking", "t", "off", "Request model reasoning effort: off|medium|high")
+
+	// structured output schema — accepts a file path or inline JSON
+	rootCmd.PersistentFlags().String("schema", "", "JSON schema for structured output (file path or inline JSON)")
 
 	// mark the mutually exclusive flags
 	rootCmd.MarkFlagsMutuallyExclusive("fast", "deep")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -158,6 +159,12 @@ func (m *Manager) Load(configPath string) error {
 		return err
 	}
 
+	// resolve and validate response_schema (file path or inline JSON).
+	// failures here surface as config errors rather than runtime 400's
+	if err := m.resolveResponseSchema(); err != nil {
+		return err
+	}
+
 	// post-process configuration to handle special cases
 	m.postProcessConfig()
 
@@ -173,6 +180,46 @@ func (m *Manager) validateThinking() error {
 	default:
 		return fmt.Errorf("invalid parameters.thinking %q: expected off|medium|high", m.cfg.Parameters.Thinking)
 	}
+}
+
+// resolveResponseSchema accepts either a file path or inline JSON on the
+// response_schema parameter. Values starting with "{" or "[" are treated
+// as inline JSON and anything else is read from disk. The resolved JSON is
+// validated and written back to the parameter
+func (m *Manager) resolveResponseSchema() error {
+	raw := strings.TrimSpace(m.cfg.Parameters.ResponseSchema)
+	if raw == "" {
+		return nil
+	}
+
+	var schemaBytes []byte
+	if raw[0] == '{' || raw[0] == '[' {
+		schemaBytes = []byte(raw)
+	} else {
+		// treat as file path —(and expand ~ if present)
+		path := raw
+		if strings.HasPrefix(path, "~") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("failed to expand home for schema path %q: %w", raw, err)
+			}
+			path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read schema file %q: %w", raw, err)
+		}
+		schemaBytes = data
+	}
+
+	// mirrors common.ValidateJSONSchema; just ensure it's valid JSON
+	var parsed interface{}
+	if err := json.Unmarshal(schemaBytes, &parsed); err != nil {
+		return fmt.Errorf("parameters.response_schema: invalid JSON schema: %w", err)
+	}
+
+	m.cfg.Parameters.ResponseSchema = string(schemaBytes)
+	return nil
 }
 
 // config returns the current configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -940,3 +940,95 @@ temperature = 0.8`, tt.seedValue)
 		})
 	}
 }
+
+// TestResolveResponseSchema covers the file / inline json schema resolution
+func TestResolveResponseSchema(t *testing.T) {
+	animalFarmSchema := `{"type":"object","properties":{"character":{"type":"string"},"quote":{"type":"string"}}}`
+
+	tmpDir := t.TempDir()
+	validSchemaPath := filepath.Join(tmpDir, "animal_farm.json")
+	if err := os.WriteFile(validSchemaPath, []byte(animalFarmSchema), 0644); err != nil {
+		t.Fatalf("failed to write schema file: %v", err)
+	}
+	malformedSchemaPath := filepath.Join(tmpDir, "malformed.json")
+	if err := os.WriteFile(malformedSchemaPath, []byte(`{"type": `), 0644); err != nil {
+		t.Fatalf("failed to write malformed schema file: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantErr      bool
+		errContains  string
+		wantResolved string
+	}{
+		{
+			name:         "Empty value is a no-op",
+			raw:          "",
+			wantErr:      false,
+			wantResolved: "",
+		},
+		{
+			name:         "Inline JSON object passes through unchanged",
+			raw:          animalFarmSchema,
+			wantErr:      false,
+			wantResolved: animalFarmSchema,
+		},
+		{
+			name:         "Inline JSON array",
+			raw:          `[1,2,3]`,
+			wantErr:      false,
+			wantResolved: `[1,2,3]`,
+		},
+		{
+			name:         "File path is read and validated",
+			raw:          validSchemaPath,
+			wantErr:      false,
+			wantResolved: animalFarmSchema,
+		},
+		{
+			name:        "Missing file surfaces a clear error",
+			raw:         filepath.Join(tmpDir, "ofc_this_isnt_here.json"),
+			wantErr:     true,
+			errContains: "failed to read schema file",
+		},
+		{
+			name:        "Malformed inline JSON is rejected at load time",
+			raw:         `{"type": `,
+			wantErr:     true,
+			errContains: "invalid JSON schema",
+		},
+		{
+			name:        "Malformed file content is rejected at load time",
+			raw:         malformedSchemaPath,
+			wantErr:     true,
+			errContains: "invalid JSON schema",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{
+				cfg: &Config{
+					Parameters: Parameters{ResponseSchema: tt.raw},
+				},
+			}
+			err := m.resolveResponseSchema()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error to contain %q, got %q", tt.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if m.cfg.Parameters.ResponseSchema != tt.wantResolved {
+				t.Errorf("expected resolved %q, got %q", tt.wantResolved, m.cfg.Parameters.ResponseSchema)
+			}
+		})
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -47,6 +47,26 @@ func validateIntRange(min, max int) func(interface{}) error {
 	}
 }
 
+// validateEnum returns a validation function that accepts only the listed strings
+// (and empty string is "use default"). See parameters.thinking for example
+func validateEnum(allowed ...string) func(interface{}) error {
+	return func(value interface{}) error {
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("expected string, got %T", value)
+		}
+		if v == "" {
+			return nil
+		}
+		for _, a := range allowed {
+			if v == a {
+				return nil
+			}
+		}
+		return fmt.Errorf("value must be one of %v, got %q", allowed, v)
+	}
+}
+
 // validateOptionalInt returns a validation function for optional int values (can be nil)
 func validateOptionalInt() func(interface{}) error {
 	return func(value interface{}) error {
@@ -120,6 +140,17 @@ func DefaultConfigSchema() *ConfigSchema {
 				Type:        reflect.TypeOf(""),
 				Description: "Default model location preference (local/remote)",
 				Default:     "remote",
+			},
+			"parameters.thinking": {
+				Type:        reflect.TypeOf(""),
+				Description: "Requested reasoning effort (off/medium/high)",
+				Default:     "off",
+				Validation:  validateEnum("off", "medium", "high"),
+			},
+			"parameters.response_schema": {
+				Type:        reflect.TypeOf(""),
+				Description: "JSON schema for structured output (file path or inline JSON)",
+				Default:     "",
 			},
 
 			// Provider API Keys
@@ -253,6 +284,10 @@ func DefaultConfigSchema() *ConfigSchema {
 			"default-model-type": "parameters.default_model_type",
 			"default-location":   "parameters.default_location",
 			"seed":               "parameters.seed",
+			"thinking":           "parameters.thinking",
+			"reasoning":          "parameters.thinking",
+			"schema":             "parameters.response_schema",
+			"response-schema":    "parameters.response_schema",
 
 			// provider api key aliases
 			"anthropic-key": "providers.anthropic.api_key",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -29,6 +29,10 @@ type Parameters struct {
 	// translated by each provider adapter into its upstream native parameter.
 	Thinking string `mapstructure:"thinking"`
 
+	// response schema for structured output — raw JSON, loaded from a file
+	// or accepted inline on the --schema flag.
+	ResponseSchema string `mapstructure:"response_schema"`
+
 	// application behavior
 	Timeout    int `mapstructure:"timeout"`
 	MaxRetries int `mapstructure:"max_retries"`

--- a/internal/llm/common/generate_test.go
+++ b/internal/llm/common/generate_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -162,6 +163,44 @@ func TestNewGenerateOptions_MultipleOptions(t *testing.T) {
 	}
 	if opts.ToolChoice != nil {
 		t.Errorf("Expected ToolChoice to remain nil, got %v", opts.ToolChoice)
+	}
+}
+
+// TestWithSchema_RoundTrip confirms WithSchema populates ResponseFormat
+// with type, name, strict, and the raw schema bytes
+// And confirms the result survives a basic JSON marshal/unmarshal cycle
+func TestWithSchema_RoundTrip(t *testing.T) {
+	schemaJSON := []byte(`{"type":"object","properties":{"character":{"type":"string"},"quote":{"type":"string"}},"required":["character","quote"]}`)
+
+	opts := NewGenerateOptions(WithSchema("animal_quote", schemaJSON))
+
+	if opts.ResponseFormat == nil {
+		t.Fatal("expected ResponseFormat to be set")
+	}
+	if opts.ResponseFormat.Type != "json_schema" {
+		t.Errorf("expected type json_schema, got %q", opts.ResponseFormat.Type)
+	}
+	if opts.ResponseFormat.Name != "animal_quote" {
+		t.Errorf("expected name animal_quote, got %q", opts.ResponseFormat.Name)
+	}
+	if opts.ResponseFormat.Strict == nil || !*opts.ResponseFormat.Strict {
+		t.Errorf("expected Strict to be true by default when schema is set")
+	}
+	if string(opts.ResponseFormat.Schema) != string(schemaJSON) {
+		t.Errorf("schema bytes did not round-trip: want %q got %q", schemaJSON, opts.ResponseFormat.Schema)
+	}
+
+	// marshal / unmarshal to confirm JSON shape is stable
+	wire, err := json.Marshal(opts.ResponseFormat)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded ResponseFormat
+	if err := json.Unmarshal(wire, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Type != "json_schema" || decoded.Name != "animal_quote" {
+		t.Errorf("decoded mismatch: %+v", decoded)
 	}
 }
 

--- a/internal/llm/common/generation.go
+++ b/internal/llm/common/generation.go
@@ -122,6 +122,24 @@ func WithJSONFormat() GenerateOption {
 	}
 }
 
+// WithSchema requests schema-constrained structured output. Adapters that
+// support it wrap the schema in their provider-specific envelope
+// (e.g.OpenAI json_schema, Anthropic output_config, and so on).
+//
+// `Strict` defaults to true so adherence is enforced where provider supports it
+// Providers that don't understand strict simply ignore the field
+func WithSchema(name string, schema []byte) GenerateOption {
+	strict := true
+	return func(c *GenerateOptions) {
+		c.ResponseFormat = &ResponseFormat{
+			Type:   "json_schema",
+			Name:   name,
+			Schema: schema,
+			Strict: &strict,
+		}
+	}
+}
+
 // WithThinking sets the requested reasoning effort. Adapters translate this
 // into their provider-specific native parameter
 // If provider/model doesn't support, silently no-op/ignore the request

--- a/internal/llm/common/provider_maxretries_test.go
+++ b/internal/llm/common/provider_maxretries_test.go
@@ -1,0 +1,151 @@
+package common_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/chriscorrea/slop/internal/config"
+	"github.com/chriscorrea/slop/internal/llm/anthropic"
+	"github.com/chriscorrea/slop/internal/llm/cohere"
+	"github.com/chriscorrea/slop/internal/llm/groq"
+	"github.com/chriscorrea/slop/internal/llm/mistral"
+	"github.com/chriscorrea/slop/internal/llm/ollama"
+	"github.com/chriscorrea/slop/internal/llm/openai"
+)
+
+func TestProviderSpecificMaxRetries(t *testing.T) {
+	tests := []struct {
+		name               string
+		setupConfig        func() *config.Config
+		providerName       string
+		expectedMaxRetries int
+	}{
+		{
+			name: "anthropic uses provider-specific max retries",
+			setupConfig: func() *config.Config {
+				cfg := config.NewDefaultFromEmbedded()
+				cfg.Parameters.MaxRetries = 1          // global default
+				cfg.Providers.Anthropic.MaxRetries = 3 // provider-specific
+				cfg.Providers.Anthropic.APIKey = "test-key"
+				return cfg
+			},
+			providerName:       "anthropic",
+			expectedMaxRetries: 3,
+		},
+		{
+			name: "anthropic falls back to global max retries when provider-specific is 0",
+			setupConfig: func() *config.Config {
+				cfg := config.NewDefaultFromEmbedded()
+				cfg.Parameters.MaxRetries = 2          // global default
+				cfg.Providers.Anthropic.MaxRetries = 0 // provider-specific not set
+				cfg.Providers.Anthropic.APIKey = "test-key"
+				return cfg
+			},
+			providerName:       "anthropic",
+			expectedMaxRetries: 2,
+		},
+		{
+			name: "openai enforces maximum limit of 5",
+			setupConfig: func() *config.Config {
+				cfg := config.NewDefaultFromEmbedded()
+				cfg.Parameters.MaxRetries = 10      // global default
+				cfg.Providers.OpenAI.MaxRetries = 8 // provider-specific
+				cfg.Providers.OpenAI.APIKey = "test-key"
+				return cfg
+			},
+			providerName:       "openai",
+			expectedMaxRetries: 5,
+		},
+		{
+			name: "cohere uses provider-specific max retries",
+			setupConfig: func() *config.Config {
+				cfg := config.NewDefaultFromEmbedded()
+				cfg.Parameters.MaxRetries = 1
+				cfg.Providers.Cohere.MaxRetries = 4
+				cfg.Providers.Cohere.APIKey = "test-key"
+				return cfg
+			},
+			providerName:       "cohere",
+			expectedMaxRetries: 4,
+		},
+		{
+			name: "groq falls back to global when provider-specific is 0",
+			setupConfig: func() *config.Config {
+				cfg := config.NewDefaultFromEmbedded()
+				cfg.Parameters.MaxRetries = 3
+				cfg.Providers.Groq.MaxRetries = 0
+				cfg.Providers.Groq.APIKey = "test-key"
+				return cfg
+			},
+			providerName:       "groq",
+			expectedMaxRetries: 3,
+		},
+		{
+			name: "mistral uses provider-specific max retries",
+			setupConfig: func() *config.Config {
+				cfg := config.NewDefaultFromEmbedded()
+				cfg.Parameters.MaxRetries = 1
+				cfg.Providers.Mistral.MaxRetries = 2
+				cfg.Providers.Mistral.APIKey = "test-key"
+				return cfg
+			},
+			providerName:       "mistral",
+			expectedMaxRetries: 2,
+		},
+		{
+			name: "ollama uses provider-specific max retries",
+			setupConfig: func() *config.Config {
+				cfg := config.NewDefaultFromEmbedded()
+				cfg.Parameters.MaxRetries = 1
+				cfg.Providers.Ollama.MaxRetries = 3
+				return cfg
+			},
+			providerName:       "ollama",
+			expectedMaxRetries: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.setupConfig()
+			logger := slog.Default()
+
+			// create provider based on name
+			var client interface{}
+			var err error
+
+			switch tt.providerName {
+			case "anthropic":
+				provider := anthropic.New()
+				client, err = provider.CreateClient(cfg, logger)
+			case "openai":
+				provider := openai.New()
+				client, err = provider.CreateClient(cfg, logger)
+			case "cohere":
+				provider := cohere.New()
+				client, err = provider.CreateClient(cfg, logger)
+			case "groq":
+				provider := groq.New()
+				client, err = provider.CreateClient(cfg, logger)
+			case "mistral":
+				provider := mistral.New()
+				client, err = provider.CreateClient(cfg, logger)
+			case "ollama":
+				provider := ollama.New()
+				client, err = provider.CreateClient(cfg, logger)
+			default:
+				t.Fatalf("Unknown provider: %s", tt.providerName)
+			}
+
+			if err != nil {
+				t.Fatalf("Failed to create client: %v", err)
+			}
+
+			// verify that client is created successfully
+			// (note we can't directly check the maxRetries value—it's internal to adappter client)
+			if client == nil {
+				t.Error("Expected client to be created, got nil")
+			}
+		})
+	}
+}

--- a/internal/llm/common/types.go
+++ b/internal/llm/common/types.go
@@ -1,5 +1,7 @@
 package common
 
+import "encoding/json"
+
 // ChatResponse represents a standard chat completion response
 type ChatResponse struct {
 	ID      string   `json:"id"`
@@ -45,7 +47,11 @@ type ErrorDetail struct {
 	Code    string `json:"code,omitempty"`
 }
 
-// ResponseFormat specifies output format for structured responses
+// ResponseFormat specifies output format for structured responses.
+// Type carries the format tag providers recognize (e.g. "json_object")
 type ResponseFormat struct {
-	Type string `json:"type"`
+	Type   string          `json:"type"`
+	Schema json.RawMessage `json:"schema,omitempty"`
+	Name   string          `json:"name,omitempty"`
+	Strict *bool           `json:"strict,omitempty"`
 }

--- a/internal/llm/common/validation.go
+++ b/internal/llm/common/validation.go
@@ -40,3 +40,15 @@ func ValidateJSONResponse(content string, config *GenerateOptions, logger *slog.
 func IsJSONFormatRequested(config *GenerateOptions) bool {
 	return config.ResponseFormat != nil && config.ResponseFormat.Type == "json_object"
 }
+
+// ValidateJSONSchema is basic check that the given bytes are valid JSON
+func ValidateJSONSchema(schema []byte) error {
+	if len(schema) == 0 {
+		return nil
+	}
+	var parsed interface{}
+	if err := json.Unmarshal(schema, &parsed); err != nil {
+		return fmt.Errorf("invalid JSON schema: %w", err)
+	}
+	return nil
+}

--- a/internal/llm/common/validation_test.go
+++ b/internal/llm/common/validation_test.go
@@ -57,6 +57,67 @@ func TestValidateJSONResponse(t *testing.T) {
 	}
 }
 
+func TestValidateJSONSchema(t *testing.T) {
+	windmillSchema := `{
+		"type": "object",
+		"properties": {
+			"character": {"type": "string"},
+			"quote": {"type": "string"}
+		},
+		"required": ["character", "quote"]
+	}`
+
+	tests := []struct {
+		name        string
+		schema      string
+		expectError bool
+		errorText   string
+	}{
+		{
+			name:        "Empty schema is allowed",
+			schema:      "",
+			expectError: false,
+		},
+		{
+			name:        "Valid object schema",
+			schema:      windmillSchema,
+			expectError: false,
+		},
+		{
+			name:        "Valid array JSON",
+			schema:      `[1, 2, 3]`,
+			expectError: false,
+		},
+		{
+			name:        "Unbalanced braces",
+			schema:      `{"type": "object"`,
+			expectError: true,
+			errorText:   "invalid JSON schema",
+		},
+		{
+			name:        "Garbage input",
+			schema:      `definitely-not-json`,
+			expectError: true,
+			errorText:   "invalid JSON schema",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateJSONSchema([]byte(tt.schema))
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				} else if !strings.Contains(err.Error(), tt.errorText) {
+					t.Errorf("expected error containing %q, got %q", tt.errorText, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
 func TestIsJSONFormatRequested(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
**Summary**: This PR adds schema-bearing ResponseFormat and the --schema CLI flag

- Extends common.ResponseFormat with Schema (json.RawMessage), Name, and Strict (*bool) so provider adapters can carry schema-constrained structured output. 

- Adds WithSchema functional option which defaults Strict=true (providers that don't support strict silently ignore the field)

- Wires the --schema persistent flag and parameters.response_schema config key

- Registers parameters.thinking and parameters.response_schema in the config schema for slop config set; adds thinking/reasoning and schema/response-schema aliases

Overall—in combination w/ thinking/reasoning trace enhancements-this PR is intended to prepare/scaffold for modernization and updates to provider integrations
