### PR TITLE
feat: adds schema passthrough and keep_alive tuning for ollama

### DIFF
--- a/internal/config/data/default_config.toml
+++ b/internal/config/data/default_config.toml
@@ -46,6 +46,7 @@ max_retries = 2
 
 [providers.ollama]
 base_url = "http://127.0.0.1:11434"
+keep_alive = "5m"
 
 [providers.mistral]
 api_key = ""

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -189,6 +189,11 @@ func DefaultConfigSchema() *ConfigSchema {
 				Description: "Ollama API base URL",
 				Default:     "http://127.0.0.1:11434",
 			},
+			"providers.ollama.keep_alive": {
+				Type:        reflect.TypeOf(""),
+				Description: "How long Ollama keeps models warm in RAM (e.g. 5m, 1h, 0)",
+				Default:     "5m",
+			},
 			"providers.mistral.api_key": {
 				Type:        reflect.TypeOf(""),
 				Description: "Mistral API key for Mistral models",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -127,6 +127,9 @@ type Mistral struct {
 
 type Ollama struct {
 	BaseProvider `mapstructure:",squash"`
+	// KeepAlive controls how long Ollama keeps a model resident in RAM
+	// after the last request (e.g. "5m", "1h", or "0" to unload eagerly).
+	KeepAlive string `mapstructure:"keep_alive"`
 }
 
 type OpenAI struct {

--- a/internal/llm/ollama/client.go
+++ b/internal/llm/ollama/client.go
@@ -1,6 +1,10 @@
 package ollama
 
-import "github.com/chriscorrea/slop/internal/llm/common"
+import (
+	"encoding/json"
+
+	"github.com/chriscorrea/slop/internal/llm/common"
+)
 
 // ChatRequest represents the request payload for Ollama's chat API
 type ChatRequest struct {
@@ -11,12 +15,18 @@ type ChatRequest struct {
 	// Generation parameters
 	Options map[string]interface{} `json:"options,omitempty"`
 
-	// Structured output support
-	Format string `json:"format,omitempty"`
+	// Structured output support. Ollama accepts either the literal JSON
+	// string "json" for free-form JSON mode or a full JSON schema object
+	// at the top-level format field
+	Format json.RawMessage `json:"format,omitempty"`
 
 	// Think enables Ollama's native thinking mode for reasoning models
 	// this is pointer so unset (nil) omits the field (rather than sending false)
 	Think *bool `json:"think,omitempty"`
+
+	// KeepAlive tunes how long the model stays warm in Ollama's memory
+	// (e.g. "5m", "1h", or "0" to unload immediately). nil omits the field
+	KeepAlive *string `json:"keep_alive,omitempty"`
 }
 
 // ChatResponse represents the response from Ollama's chat API

--- a/internal/llm/ollama/options.go
+++ b/internal/llm/ollama/options.go
@@ -11,6 +11,7 @@ type GenerateOptions struct {
 	RepeatPenalty *float64 // Penalty for repeating tokens (default: 1.1)
 	Seed          *int     // Random seed for deterministic generation
 	Think         *bool    // native think flag for structured reasoning
+	KeepAlive     *string  // how long Ollama keeps the model warm in RAM
 }
 
 // GenerateOption configures Ollama-specific generation parameters
@@ -54,6 +55,14 @@ func WithSeed(seed int) GenerateOption {
 func WithThink(think bool) GenerateOption {
 	return func(c *GenerateOptions) {
 		c.Think = &think
+	}
+}
+
+// WithKeepAlive tunes how long Ollama keeps the model warm in RAM after a
+// request. Accepts Go-style durations ("5m", "1h") or "0" to unload.
+func WithKeepAlive(s string) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.KeepAlive = &s
 	}
 }
 

--- a/internal/llm/ollama/provider.go
+++ b/internal/llm/ollama/provider.go
@@ -74,11 +74,26 @@ func (p *Provider) BuildOptions(cfg *config.Config) []interface{} {
 		functionalOpts = append(functionalOpts, WithJSONFormat())
 	}
 
+	// populate ResponseFormat with the user's schema when supplied.
+	// Parameters.ResponseSchema is resolved to inline JSON at config-load
+	// time, so the raw bytes are ready for direct passthrough.
+	if cfg.Parameters.ResponseSchema != "" {
+		schemaOpt := common.WithSchema("response", []byte(cfg.Parameters.ResponseSchema))
+		functionalOpts = append(functionalOpts, func(o *GenerateOptions) {
+			schemaOpt(&o.GenerateOptions)
+		})
+	}
+
 	// translate the cross-provider thinking level into Ollama's native
 	// think flag. Silent no-op for ThinkingOff and unknown values, so a
 	// user's config default survives switching to a non-thinking model.
 	if level, err := common.ParseThinkingLevel(cfg.Parameters.Thinking); err == nil && level != common.ThinkingOff {
 		functionalOpts = append(functionalOpts, WithThink(true))
+	}
+
+	// pass through the provider-scoped keep_alive tuning when set
+	if cfg.Providers.Ollama.KeepAlive != "" {
+		functionalOpts = append(functionalOpts, WithKeepAlive(cfg.Providers.Ollama.KeepAlive))
 	}
 
 	return []interface{}{NewGenerateOptions(functionalOpts...)}
@@ -151,14 +166,28 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		requestBody.Options = optionsMap
 	}
 
-	// handle structured output if requested
-	if config.ResponseFormat != nil && config.ResponseFormat.Type == "json_object" {
-		requestBody.Format = "json"
+	// handle structured output if requested. Ollama accepts either the
+	// literal string "json" for unconstrained JSON mode or a full JSON
+	// schema object; both go in the top-level format field
+	if config.ResponseFormat != nil {
+		switch config.ResponseFormat.Type {
+		case "json_object":
+			requestBody.Format = json.RawMessage(`"json"`)
+		case "json_schema":
+			if len(config.ResponseFormat.Schema) > 0 {
+				requestBody.Format = config.ResponseFormat.Schema
+			}
+		}
 	}
 
 	// wire the native think flag through to the API
 	if config.Think != nil {
 		requestBody.Think = config.Think
+	}
+
+	// wire keep_alive through so users can tune model residency in RAM
+	if config.KeepAlive != nil {
+		requestBody.KeepAlive = config.KeepAlive
 	}
 
 	return requestBody, nil

--- a/internal/llm/ollama/provider_test.go
+++ b/internal/llm/ollama/provider_test.go
@@ -1,6 +1,7 @@
 package ollama
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -144,7 +145,33 @@ func TestBuildRequest(t *testing.T) {
 			validate: func(t *testing.T, request interface{}) {
 				chatReq, ok := request.(*ChatRequest)
 				assert.True(t, ok, "Request should be *ChatRequest")
-				assert.Equal(t, "json", chatReq.Format)
+				assert.JSONEq(t, `"json"`, string(chatReq.Format))
+			},
+		},
+		{
+			name: "Build request with JSON schema passthrough",
+			options: func() interface{} {
+				schema := []byte(`{"type":"object","properties":{"quote":{"type":"string"}},"required":["quote"]}`)
+				return NewGenerateOptions(func(o *GenerateOptions) {
+					common.WithSchema("character_quote", schema)(&o.GenerateOptions)
+				})
+			}(),
+			validate: func(t *testing.T, request interface{}) {
+				chatReq, ok := request.(*ChatRequest)
+				assert.True(t, ok, "Request should be *ChatRequest")
+				expected := `{"type":"object","properties":{"quote":{"type":"string"}},"required":["quote"]}`
+				assert.JSONEq(t, expected, string(chatReq.Format))
+			},
+		},
+		{
+			name:    "Build request wires keep_alive",
+			options: NewGenerateOptions(WithKeepAlive("10m")),
+			validate: func(t *testing.T, request interface{}) {
+				chatReq, ok := request.(*ChatRequest)
+				assert.True(t, ok, "Request should be *ChatRequest")
+				if assert.NotNil(t, chatReq.KeepAlive) {
+					assert.Equal(t, "10m", *chatReq.KeepAlive)
+				}
 			},
 		},
 	}
@@ -424,6 +451,89 @@ func TestParseResponse_NoThinking(t *testing.T) {
 	assert.Equal(t, "Four legs good, two legs bad.", content)
 }
 
+// TestBuildOptions_KeepAlive confirms the provider-scoped keep_alive config
+// surfaces as a request-level KeepAlive option.
+func TestBuildOptions_KeepAlive(t *testing.T) {
+	provider := New()
+
+	tests := []struct {
+		name          string
+		keepAlive     string
+		wantKeepAlive *string
+	}{
+		{name: "empty is omitted", keepAlive: "", wantKeepAlive: nil},
+		{name: "5m passes through", keepAlive: "5m", wantKeepAlive: stringPtr("5m")},
+		{name: "zero unloads", keepAlive: "0", wantKeepAlive: stringPtr("0")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Providers: config.Providers{
+					Ollama: config.Ollama{KeepAlive: tt.keepAlive},
+				},
+			}
+			opts := provider.BuildOptions(cfg)
+			require := assert.New(t)
+			require.Len(opts, 1)
+			ollamaOpts, ok := opts[0].(*GenerateOptions)
+			require.True(ok)
+
+			if tt.wantKeepAlive == nil {
+				require.Nil(ollamaOpts.KeepAlive)
+			} else {
+				require.NotNil(ollamaOpts.KeepAlive)
+				require.Equal(*tt.wantKeepAlive, *ollamaOpts.KeepAlive)
+			}
+
+			// verify it also reaches the final request body
+			req, err := provider.BuildRequest(nil, "gemma4:latest", ollamaOpts, slog.Default())
+			require.NoError(err)
+			chatReq, ok := req.(*ChatRequest)
+			require.True(ok)
+			if tt.wantKeepAlive == nil {
+				require.Nil(chatReq.KeepAlive)
+			} else {
+				require.NotNil(chatReq.KeepAlive)
+				require.Equal(*tt.wantKeepAlive, *chatReq.KeepAlive)
+			}
+		})
+	}
+}
+
+// TestBuildOptions_ResponseSchema confirms cfg.Parameters.ResponseSchema
+// is wrapped into ResponseFormat and passed through to the request body.
+func TestBuildOptions_ResponseSchema(t *testing.T) {
+	provider := New()
+	schema := `{"type":"object","properties":{"animal":{"type":"string"}},"required":["animal"]}`
+	cfg := &config.Config{
+		Parameters: config.Parameters{ResponseSchema: schema},
+	}
+
+	opts := provider.BuildOptions(cfg)
+	require := assert.New(t)
+	require.Len(opts, 1)
+	ollamaOpts, ok := opts[0].(*GenerateOptions)
+	require.True(ok)
+	require.NotNil(ollamaOpts.ResponseFormat)
+	require.Equal("json_schema", ollamaOpts.ResponseFormat.Type)
+	require.JSONEq(schema, string(ollamaOpts.ResponseFormat.Schema))
+
+	req, err := provider.BuildRequest(nil, "gemma4:latest", ollamaOpts, slog.Default())
+	require.NoError(err)
+	chatReq, ok := req.(*ChatRequest)
+	require.True(ok)
+	require.JSONEq(schema, string(chatReq.Format))
+
+	// raw JSON bytes must be identical (not re-encoded, not a string literal)
+	var format json.RawMessage = chatReq.Format
+	require.NotEqual(`"json"`, string(format))
+}
+
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
ChatRequest.Format is now json.RawMessage so Ollama's native format field can carry either the literal "json" for unconstrained JSON mode or a full JSON schema object for schema-constrained structured output. 

Adds a provider-scoped keep_alive string (default "5m") so users can tune how long Ollama keeps models warm in RAM.