### PR TITLE
feat: adds anthropic (adaptive) thinking integration and structured outputs 

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,7 @@ import (
 )
 
 // current version (hardcoded for now, could be replaced with build flags)
-const version = "0.1.2"
+const version = "0.2.0"
 
 // rootCmdState holds the config manager and logger for the command
 type rootCmdState struct {

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -1,6 +1,10 @@
 package anthropic
 
-import "github.com/chriscorrea/slop/internal/llm/common"
+import (
+	"encoding/json"
+
+	"github.com/chriscorrea/slop/internal/llm/common"
+)
 
 // MessagesRequest represents the request payload for Anthropic's Messages API
 type MessagesRequest struct {
@@ -13,6 +17,37 @@ type MessagesRequest struct {
 	TopK          *int             `json:"top_k,omitempty"`
 	StopSequences []string         `json:"stop_sequences,omitempty"`
 	Stream        *bool            `json:"stream,omitempty"`
+
+	// Thinking carries the extended thinking config. When nil, the field
+	// is omitted and the model behaves as normal
+	Thinking *ThinkingConfig `json:"thinking,omitempty"`
+
+	// OutputConfig carries the structured-output envelope. Anthropic
+	// wraps the json_schema response format under output_config.format
+	OutputConfig *OutputConfig `json:"output_config,omitempty"`
+}
+
+// ThinkingConfig wires Anthropic's extended-thinking block. Type is
+// "enabled" when set; budget_tokens bounds how many tokens the model
+// may spend on internal reasoning
+type ThinkingConfig struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens"`
+}
+
+// OutputConfig wraps Anthropic's structured-output envelope on the
+// Messages API. Format carries the schema and its metadata
+type OutputConfig struct {
+	Format *OutputFormat `json:"format,omitempty"`
+}
+
+// OutputFormat describes a single structured-output format. For
+// json_schema requests, Name, Schema, and Strict are set
+type OutputFormat struct {
+	Type   string          `json:"type"`
+	Name   string          `json:"name,omitempty"`
+	Schema json.RawMessage `json:"schema,omitempty"`
+	Strict *bool           `json:"strict,omitempty"`
 }
 
 // MessagesResponse represents Anthropic's Messages API response
@@ -27,10 +62,13 @@ type MessagesResponse struct {
 	Usage        AnthropicUsage `json:"usage"`
 }
 
-// ContentItem represents a content item in Anthropic's response
+// ContentItem represents a content item in Anthropic's response.
+// Text carries the body of a "text" block; Thinking carries the body
+// of a "thinking" block emitted when extended thinking is enabled
 type ContentItem struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	Thinking string `json:"thinking,omitempty"`
 }
 
 // AnthropicUsage represents usage information in Anthropic's format

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -27,20 +27,22 @@ type MessagesRequest struct {
 	OutputConfig *OutputConfig `json:"output_config,omitempty"`
 }
 
-// ThinkingConfig wires Anthropic's extended-thinking block. BudgetTokens
-// is used with Type="enabled" on 4.5 and earlier; Effort is used with
-// Type="adaptive" on 4.6+ models. The two shapes are mutually exclusive
-// and omitempty lets each serialize cleanly.
+// ThinkingConfig wires Anthropic's extended-thinking block. Type is
+// "enabled" with a BudgetTokens ceiling on 4.5 and earlier; Type is
+// "adaptive" (no budget) on 4.6+. Effort for adaptive routing lives on
+// OutputConfig, not here
 type ThinkingConfig struct {
 	Type         string `json:"type"`
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
-	Effort       string `json:"effort,omitempty"`
 }
 
 // OutputConfig wraps Anthropic's structured-output envelope on the
-// Messages API. Format carries the schema and its metadata
+// Messages API. Format carries the schema and its metadata; Effort
+// controls token spend on models that support it (low/medium/high/max).
+// Both fields may be set together
 type OutputConfig struct {
 	Format *OutputFormat `json:"format,omitempty"`
+	Effort string        `json:"effort,omitempty"`
 }
 
 // OutputFormat describes a single structured-output format. For

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -27,12 +27,14 @@ type MessagesRequest struct {
 	OutputConfig *OutputConfig `json:"output_config,omitempty"`
 }
 
-// ThinkingConfig wires Anthropic's extended-thinking block. Type is
-// "enabled" when set; budget_tokens bounds how many tokens the model
-// may spend on internal reasoning
+// ThinkingConfig wires Anthropic's extended-thinking block. BudgetTokens
+// is used with Type="enabled" on 4.5 and earlier; Effort is used with
+// Type="adaptive" on 4.6+ models. The two shapes are mutually exclusive
+// and omitempty lets each serialize cleanly.
 type ThinkingConfig struct {
 	Type         string `json:"type"`
-	BudgetTokens int    `json:"budget_tokens"`
+	BudgetTokens int    `json:"budget_tokens,omitempty"`
+	Effort       string `json:"effort,omitempty"`
 }
 
 // OutputConfig wraps Anthropic's structured-output envelope on the

--- a/internal/llm/anthropic/options.go
+++ b/internal/llm/anthropic/options.go
@@ -10,6 +10,11 @@ type GenerateOptions struct {
 	TopK          *int     // integer for top-k sampling (only used by some Anthropic models)
 	System        string   // system prompt for Anthropic (separate from messages)
 	StopSequences []string // anthropic uses "stop_sequences" instead of "stop"
+
+	// ThinkingBudget overrides the budget_tokens value Anthropic sees when
+	// extended thinking is enabled. When zero, the adapter derives a budget
+	// from the cross-provider ThinkingLevel (medium: 4000, high: 16000)
+	ThinkingBudget int
 }
 
 // GenerateOption configures Anthropic-specific generation parameters
@@ -42,6 +47,32 @@ func WithSystem(system string) GenerateOption {
 func WithStopSequences(sequences []string) GenerateOption {
 	return func(c *GenerateOptions) {
 		c.StopSequences = sequences
+	}
+}
+
+// WithThinkingBudget overrides the budget_tokens value Anthropic receives
+// when extended thinking is enabled. A value of zero lets the adapter
+// pick a default based on the cross-provider ThinkingLevel
+func WithThinkingBudget(budget int) GenerateOption {
+	return func(c *GenerateOptions) {
+		c.ThinkingBudget = budget
+	}
+}
+
+// WithThinking sets the cross-provider thinking level. Anthropic's adapter
+// translates this into a thinking block with an appropriate budget
+func WithThinking(level common.ThinkingLevel) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithThinking(level)(&c.GenerateOptions)
+	}
+}
+
+// WithSchema requests schema-constrained structured output via Anthropic's
+// output_config envelope. The schema is forwarded to the common layer and
+// the adapter wires it onto the wire-level OutputConfig at request build
+func WithSchema(name string, schema []byte) GenerateOption {
+	return func(c *GenerateOptions) {
+		common.WithSchema(name, schema)(&c.GenerateOptions)
 	}
 }
 

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/chriscorrea/slop/internal/config"
@@ -182,6 +184,72 @@ func defaultMaxTokens(modelID string) int {
 	return maxTokensDefault
 }
 
+// anthropicVersionRE captures a trailing -<major>-<minor> suffix where the
+// minor is one or two digits. that excludes 4.0-era date snapshots like
+// claude-sonnet-4-20250514, whose minor component is an eight-digit date
+var anthropicVersionRE = regexp.MustCompile(`-(\d+)-(\d{1,2})(?:-|$)`)
+
+// parseAnthropicVersion extracts the major.minor from a Claude model id,
+// or returns ok=false if no standard version suffix is detectable
+func parseAnthropicVersion(modelID string) (major, minor int, ok bool) {
+	m := anthropicVersionRE.FindStringSubmatch(strings.ToLower(modelID))
+	if m == nil {
+		return 0, 0, false
+	}
+	maj, err1 := strconv.Atoi(m[1])
+	min, err2 := strconv.Atoi(m[2])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return maj, min, true
+}
+
+// useAdaptiveThinking reports whether a model accepts Anthropic's adaptive
+// thinking shape. 4.6 and later use adaptive+effort; 4.5 and earlier stay
+// on the enabled+budget_tokens shape
+func useAdaptiveThinking(modelID string) bool {
+	major, minor, ok := parseAnthropicVersion(modelID)
+	if !ok {
+		return false
+	}
+	return major > 4 || (major == 4 && minor >= 6)
+}
+
+// supportsMaxEffort reports whether a model accepts effort="max". per
+// Anthropic's docs, max is available on Opus 4.6, Opus 4.7, Sonnet 4.6,
+// and the Mythos preview family. other adaptive models top out at "high"
+func supportsMaxEffort(modelID string) bool {
+	id := strings.ToLower(modelID)
+	switch {
+	case strings.HasPrefix(id, "claude-opus-4-6"):
+		return true
+	case strings.HasPrefix(id, "claude-opus-4-7"):
+		return true
+	case strings.HasPrefix(id, "claude-sonnet-4-6"):
+		return true
+	case strings.HasPrefix(id, "claude-mythos"):
+		return true
+	}
+	return false
+}
+
+// effortForLevel maps slop's ThinkingLevel onto Anthropic's adaptive
+// effort string. ThinkingHigh upgrades to "max" on models that support it,
+// otherwise it falls back to "high"
+func effortForLevel(level common.ThinkingLevel, maxOK bool) string {
+	switch level {
+	case common.ThinkingHigh:
+		if maxOK {
+			return "max"
+		}
+		return "high"
+	case common.ThinkingMedium:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
 // BuildRequest creates an Anthropic-specific request from messages and options
 func (p *Provider) BuildRequest(messages []common.Message, modelName string, options interface{}, logger *slog.Logger) (interface{}, error) {
 	// convert options to Anthropic-specific options
@@ -253,33 +321,46 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		requestBody.StopSequences = config.StopSequences
 	}
 
-	// extended thinking: only emit on models that accept it. silent
-	// no-op for unsupported models so a user's default config survives
-	// switching to, say, haiku
-	if config.Thinking != common.ThinkingOff && supportsThinking(modelName) {
-		budget := config.ThinkingBudget
-		if budget <= 0 {
-			budget = thinkingBudget(config.Thinking)
-		}
-		requestBody.Thinking = &ThinkingConfig{
-			Type:         "enabled",
-			BudgetTokens: budget,
-		}
-
-		// Anthropic requires max_tokens > budget_tokens. bump the ceiling
-		// when the caller's value is too tight so --thinking high still
-		// has room to deliver an answer on top of its reasoning tokens
-		if requestBody.MaxTokens <= budget {
-			adjusted := budget + maxTokensDefault
-			if logger != nil {
-				logger.Debug("adjusting max_tokens to satisfy thinking budget",
-					"model", modelName,
-					"budget_tokens", budget,
-					"original_max_tokens", requestBody.MaxTokens,
-					"adjusted_max_tokens", adjusted,
-				)
+	// extended thinking. the shape depends on the model:
+	//   4.6+ — always send adaptive+effort (off maps to low, so the model
+	//          may still skip thinking on simple prompts)
+	//   4.5- — only send enabled+budget_tokens when the user asked for
+	//          medium or high; off stays literal (no block at all)
+	// unsupported models silently no-op so a default --thinking setting
+	// survives switching to something like haiku
+	if supportsThinking(modelName) {
+		if useAdaptiveThinking(modelName) {
+			requestBody.Thinking = &ThinkingConfig{
+				Type:   "adaptive",
+				Effort: effortForLevel(config.Thinking, supportsMaxEffort(modelName)),
 			}
-			requestBody.MaxTokens = adjusted
+			// adaptive auto-manages tokens; no max_tokens bump needed
+		} else if config.Thinking != common.ThinkingOff {
+			budget := config.ThinkingBudget
+			if budget <= 0 {
+				budget = thinkingBudget(config.Thinking)
+			}
+			requestBody.Thinking = &ThinkingConfig{
+				Type:         "enabled",
+				BudgetTokens: budget,
+			}
+
+			// Anthropic requires max_tokens > budget_tokens on the legacy
+			// shape. bump the ceiling when the caller's value is too tight
+			// so --thinking high still has room to deliver an answer on top
+			// of its reasoning tokens
+			if requestBody.MaxTokens <= budget {
+				adjusted := budget + maxTokensDefault
+				if logger != nil {
+					logger.Debug("adjusting max_tokens to satisfy thinking budget",
+						"model", modelName,
+						"budget_tokens", budget,
+						"original_max_tokens", requestBody.MaxTokens,
+						"adjusted_max_tokens", adjusted,
+					)
+				}
+				requestBody.MaxTokens = adjusted
+			}
 		}
 	}
 

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -27,6 +27,22 @@ type Provider struct{}
 // ensure Provider implements the common provider interface
 var _ common.Provider = (*Provider)(nil)
 
+// thinking budget defaults keyed on the cross-provider ThinkingLevel.
+// medium targets moderate reasoning; high gives the model room to explore
+const (
+	thinkingBudgetMedium = 4000
+	thinkingBudgetHigh   = 16000
+)
+
+// per-model max_tokens defaults. these keep headroom for extended thinking
+// plus a generous completion on the larger Opus/Sonnet families while still
+// matching smaller models' practical output sizes
+const (
+	maxTokensDefault       = 4096
+	maxTokensSonnetFamily4 = 16384
+	maxTokensOpusFamily4   = 32768
+)
+
 // New creates a new Anthropic provider instance
 func New() *Provider {
 	return &Provider{}
@@ -94,6 +110,21 @@ func (p *Provider) BuildOptions(cfg *config.Config) []interface{} {
 		functionalOpts = append(functionalOpts, WithJSONFormat())
 	}
 
+	// translate the cross-provider thinking level into Anthropic's native
+	// extended-thinking block at request build time. silent no-op for
+	// ThinkingOff and unknown values, so a user's config default survives
+	// switching to a non-thinking model.
+	if level, err := common.ParseThinkingLevel(cfg.Parameters.Thinking); err == nil && level != common.ThinkingOff {
+		functionalOpts = append(functionalOpts, WithThinking(level))
+	}
+
+	// forward the pre-resolved response schema through common.WithSchema.
+	// the adapter wires the schema onto Anthropic's output_config envelope
+	// at request build time.
+	if schema := strings.TrimSpace(cfg.Parameters.ResponseSchema); schema != "" {
+		functionalOpts = append(functionalOpts, WithSchema("response", []byte(schema)))
+	}
+
 	return []interface{}{NewGenerateOptions(functionalOpts...)}
 }
 
@@ -105,6 +136,50 @@ func (p *Provider) RequiresAPIKey() bool {
 // returns the name of this provider
 func (p *Provider) ProviderName() string {
 	return "anthropic"
+}
+
+// supportsThinking reports whether a model id accepts the extended-thinking
+// block. conservative allowlist; unknown models silently skip the field so
+// a stray --thinking flag never breaks a request
+func supportsThinking(modelID string) bool {
+	id := strings.ToLower(modelID)
+	switch {
+	case strings.HasPrefix(id, "claude-sonnet-4-"):
+		return true
+	case strings.HasPrefix(id, "claude-opus-4-"):
+		return true
+	case strings.HasPrefix(id, "claude-3-7-sonnet"):
+		return true
+	}
+	return false
+}
+
+// thinkingBudget maps a cross-provider ThinkingLevel onto Anthropic's
+// budget_tokens parameter. unknown levels get the medium budget so a
+// caller with a stale level still gets a reasonable request
+func thinkingBudget(level common.ThinkingLevel) int {
+	switch level {
+	case common.ThinkingHigh:
+		return thinkingBudgetHigh
+	case common.ThinkingMedium:
+		return thinkingBudgetMedium
+	default:
+		return thinkingBudgetMedium
+	}
+}
+
+// defaultMaxTokens returns a reasonable max_tokens value for a given model
+// when the caller hasn't set one. claude-opus-4-* gets the largest budget,
+// claude-sonnet-4-* a middle budget, everything else a modest default
+func defaultMaxTokens(modelID string) int {
+	id := strings.ToLower(modelID)
+	switch {
+	case strings.HasPrefix(id, "claude-opus-4-"):
+		return maxTokensOpusFamily4
+	case strings.HasPrefix(id, "claude-sonnet-4-"):
+		return maxTokensSonnetFamily4
+	}
+	return maxTokensDefault
 }
 
 // BuildRequest creates an Anthropic-specific request from messages and options
@@ -145,12 +220,13 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		systemPrompt = config.System
 	}
 
-	// create Anthropic-specific request payload
+	// create Anthropic-specific request payload. Anthropic requires
+	// max_tokens, so seed a per-model default the caller can override
 	requestBody := &MessagesRequest{
 		Model:     modelName,
 		Messages:  filteredMessages,
-		MaxTokens: 1024,                  // Anthropic requires max_tokens, so we set a default
-		Stream:    common.BoolPtr(false), // Disable streaming for now
+		MaxTokens: defaultMaxTokens(modelName),
+		Stream:    common.BoolPtr(false), // disable streaming for now
 	}
 
 	// set system prompt if provided
@@ -177,10 +253,57 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		requestBody.StopSequences = config.StopSequences
 	}
 
+	// extended thinking: only emit on models that accept it. silent
+	// no-op for unsupported models so a user's default config survives
+	// switching to, say, haiku
+	if config.Thinking != common.ThinkingOff && supportsThinking(modelName) {
+		budget := config.ThinkingBudget
+		if budget <= 0 {
+			budget = thinkingBudget(config.Thinking)
+		}
+		requestBody.Thinking = &ThinkingConfig{
+			Type:         "enabled",
+			BudgetTokens: budget,
+		}
+
+		// Anthropic requires max_tokens > budget_tokens. bump the ceiling
+		// when the caller's value is too tight so --thinking high still
+		// has room to deliver an answer on top of its reasoning tokens
+		if requestBody.MaxTokens <= budget {
+			adjusted := budget + maxTokensDefault
+			if logger != nil {
+				logger.Debug("adjusting max_tokens to satisfy thinking budget",
+					"model", modelName,
+					"budget_tokens", budget,
+					"original_max_tokens", requestBody.MaxTokens,
+					"adjusted_max_tokens", adjusted,
+				)
+			}
+			requestBody.MaxTokens = adjusted
+		}
+	}
+
+	// structured output: wrap json_schema requests in Anthropic's
+	// output_config envelope. non-schema formats (e.g. json_object) fall
+	// through unchanged — Anthropic doesn't have a parallel for those
+	if rf := config.ResponseFormat; rf != nil && rf.Type == "json_schema" && len(rf.Schema) > 0 {
+		requestBody.OutputConfig = &OutputConfig{
+			Format: &OutputFormat{
+				Type:   "json_schema",
+				Name:   rf.Name,
+				Schema: rf.Schema,
+				Strict: rf.Strict,
+			},
+		}
+	}
+
 	return requestBody, nil
 }
 
-// ParseResponse parses an Anthropic API response and extracts content and usage
+// ParseResponse parses an Anthropic API response and extracts content and usage.
+// thinking blocks are re-inlined as a <think>...</think> prefix on the content
+// string so downstream format.ApplyThinkingFilter treats Anthropic's structured
+// thinking identically to an inline-tag thinking stream
 func (p *Provider) ParseResponse(body []byte, logger *slog.Logger) (string, *common.Usage, error) {
 	// parse the response using Anthropic's Messages API format
 	var anthropicResp MessagesResponse
@@ -194,19 +317,35 @@ func (p *Provider) ParseResponse(body []byte, logger *slog.Logger) (string, *com
 		return "", nil, fmt.Errorf("no content in Anthropic response")
 	}
 
-	// concatenate all text content items
-	var contentParts []string
+	// walk the content array once, collecting text and thinking blocks
+	// into separate buffers. Anthropic emits thinking blocks before the
+	// text block they precede, so preserving order is not required — we
+	// just concatenate each kind in stream order
+	var textParts []string
+	var thinkingParts []string
 	for _, item := range anthropicResp.Content {
-		if item.Type == "text" {
-			contentParts = append(contentParts, item.Text)
+		switch item.Type {
+		case "text":
+			textParts = append(textParts, item.Text)
+		case "thinking":
+			if item.Thinking != "" {
+				thinkingParts = append(thinkingParts, item.Thinking)
+			}
 		}
 	}
 
-	if len(contentParts) == 0 {
+	if len(textParts) == 0 {
 		return "", nil, fmt.Errorf("no text content in Anthropic response")
 	}
 
-	content := strings.Join(contentParts, "")
+	content := strings.Join(textParts, "")
+
+	// re-inline thinking as a <think> tag so the downstream filter treats
+	// Anthropic structured thinking the same as any other provider's
+	// inline-tag thinking stream
+	if len(thinkingParts) > 0 {
+		content = "<think>" + strings.Join(thinkingParts, "") + "</think>\n" + content
+	}
 
 	// convert Anthropic usage to common format
 	var usage *common.Usage
@@ -230,7 +369,7 @@ func (p *Provider) HandleError(statusCode int, body []byte) error {
 	case http.StatusUnauthorized:
 		return fmt.Errorf(`Anthropic API authentication failed.
 
-Check your API key and ensure it is set correctly. 
+Check your API key and ensure it is set correctly.
 You can set the API key using the environment variable ANTHROPIC_API_KEY or via slop config set anthropic-key=<your_api_key>
 Get an API key from https://console.anthropic.com/settings/keys`)
 

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -394,9 +394,10 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 	}
 
 	// Anthropic only accepts temperature=1 whenever the thinking block is
-	// present (adaptive or enabled). override a caller-set value with a
-	// debug log so a --temperature 0.7 default survives switching models
-	// that don't use thinking
+	// present (adaptive or enabled), and models like Sonnet 4.6 reject
+	// requests that set both temperature and top_p. force temperature to 1
+	// and drop top_p so a --temperature/--top-p default survives switching
+	// models that don't use thinking
 	if requestBody.Thinking != nil {
 		if requestBody.Temperature != nil && *requestBody.Temperature != 1 && logger != nil {
 			logger.Debug("overriding temperature to 1 for extended thinking",
@@ -406,6 +407,14 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		}
 		one := 1.0
 		requestBody.Temperature = &one
+
+		if requestBody.TopP != nil && logger != nil {
+			logger.Debug("dropping top_p to satisfy anthropic's temperature/top_p exclusion",
+				"model", modelName,
+				"original_top_p", *requestBody.TopP,
+			)
+		}
+		requestBody.TopP = nil
 	}
 
 	// structured output: wrap json_schema requests in Anthropic's

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -215,6 +215,27 @@ func useAdaptiveThinking(modelID string) bool {
 	return major > 4 || (major == 4 && minor >= 6)
 }
 
+// supportsEffort reports whether a model accepts the output_config.effort
+// parameter. per Anthropic's docs: Mythos Preview, Opus 4.5, Opus 4.6,
+// Opus 4.7, and Sonnet 4.6. note that Opus 4.5 supports effort even
+// though it uses manual (enabled+budget_tokens) thinking
+func supportsEffort(modelID string) bool {
+	id := strings.ToLower(modelID)
+	switch {
+	case strings.HasPrefix(id, "claude-opus-4-5"):
+		return true
+	case strings.HasPrefix(id, "claude-opus-4-6"):
+		return true
+	case strings.HasPrefix(id, "claude-opus-4-7"):
+		return true
+	case strings.HasPrefix(id, "claude-sonnet-4-6"):
+		return true
+	case strings.HasPrefix(id, "claude-mythos"):
+		return true
+	}
+	return false
+}
+
 // supportsMaxEffort reports whether a model accepts effort="max". per
 // Anthropic's docs, max is available on Opus 4.6, Opus 4.7, Sonnet 4.6,
 // and the Mythos preview family. other adaptive models top out at "high"
@@ -321,19 +342,17 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		requestBody.StopSequences = config.StopSequences
 	}
 
-	// extended thinking. the shape depends on the model:
-	//   4.6+ — always send adaptive+effort (off maps to low, so the model
-	//          may still skip thinking on simple prompts)
-	//   4.5- — only send enabled+budget_tokens when the user asked for
-	//          medium or high; off stays literal (no block at all)
+	// extended thinking block. the shape depends on the model:
+	//   4.6+ — adaptive (no budget); the output_config.effort lever below
+	//          steers depth, so we skip the thinking block only when the
+	//          model doesn't support thinking at all
+	//   4.5- — enabled+budget_tokens when the user asked for medium/high;
+	//          off stays literal (no block at all)
 	// unsupported models silently no-op so a default --thinking setting
 	// survives switching to something like haiku
 	if supportsThinking(modelName) {
 		if useAdaptiveThinking(modelName) {
-			requestBody.Thinking = &ThinkingConfig{
-				Type:   "adaptive",
-				Effort: effortForLevel(config.Thinking, supportsMaxEffort(modelName)),
-			}
+			requestBody.Thinking = &ThinkingConfig{Type: "adaptive"}
 			// adaptive auto-manages tokens; no max_tokens bump needed
 		} else if config.Thinking != common.ThinkingOff {
 			budget := config.ThinkingBudget
@@ -364,17 +383,29 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		}
 	}
 
+	// effort lever on output_config. the allowlist is independent of
+	// supportsThinking — Opus 4.5 uses manual thinking but still accepts
+	// effort, and Mythos supports effort with adaptive-by-default
+	if supportsEffort(modelName) {
+		if requestBody.OutputConfig == nil {
+			requestBody.OutputConfig = &OutputConfig{}
+		}
+		requestBody.OutputConfig.Effort = effortForLevel(config.Thinking, supportsMaxEffort(modelName))
+	}
+
 	// structured output: wrap json_schema requests in Anthropic's
 	// output_config envelope. non-schema formats (e.g. json_object) fall
-	// through unchanged — Anthropic doesn't have a parallel for those
+	// through unchanged — Anthropic doesn't have a parallel for those.
+	// merge onto the existing OutputConfig so an effort setting survives
 	if rf := config.ResponseFormat; rf != nil && rf.Type == "json_schema" && len(rf.Schema) > 0 {
-		requestBody.OutputConfig = &OutputConfig{
-			Format: &OutputFormat{
-				Type:   "json_schema",
-				Name:   rf.Name,
-				Schema: rf.Schema,
-				Strict: rf.Strict,
-			},
+		if requestBody.OutputConfig == nil {
+			requestBody.OutputConfig = &OutputConfig{}
+		}
+		requestBody.OutputConfig.Format = &OutputFormat{
+			Type:   "json_schema",
+			Name:   rf.Name,
+			Schema: rf.Schema,
+			Strict: rf.Strict,
 		}
 	}
 

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -393,6 +393,21 @@ func (p *Provider) BuildRequest(messages []common.Message, modelName string, opt
 		requestBody.OutputConfig.Effort = effortForLevel(config.Thinking, supportsMaxEffort(modelName))
 	}
 
+	// Anthropic only accepts temperature=1 whenever the thinking block is
+	// present (adaptive or enabled). override a caller-set value with a
+	// debug log so a --temperature 0.7 default survives switching models
+	// that don't use thinking
+	if requestBody.Thinking != nil {
+		if requestBody.Temperature != nil && *requestBody.Temperature != 1 && logger != nil {
+			logger.Debug("overriding temperature to 1 for extended thinking",
+				"model", modelName,
+				"original_temperature", *requestBody.Temperature,
+			)
+		}
+		one := 1.0
+		requestBody.Temperature = &one
+	}
+
 	// structured output: wrap json_schema requests in Anthropic's
 	// output_config envelope. non-schema formats (e.g. json_object) fall
 	// through unchanged — Anthropic doesn't have a parallel for those.

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -696,37 +696,40 @@ func TestDefaultMaxTokens(t *testing.T) {
 	}
 }
 
-// TestBuildRequest_Thinking covers the cross-provider ThinkingLevel →
-// Anthropic thinking-block translation, including the model id gate and
-// the max_tokens/budget_tokens constraint.
+// TestBuildRequest_Thinking covers the legacy enabled+budget_tokens path
+// used for 4.5 and earlier Claude models. Model ids are pinned to 4.5 so
+// the adaptive routing doesn't intercept these cases.
 func TestBuildRequest_Thinking(t *testing.T) {
 	provider := New()
 	messages := []common.Message{
 		{Role: "user", Content: "Why does Boxer trust Napoleon?"},
 	}
 
-	t.Run("high on sonnet 4.6 sets budget 16000 and bumps max_tokens", func(t *testing.T) {
+	t.Run("high on sonnet 4.5 sets budget 16000 and bumps max_tokens", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
-		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
 		require.NoError(t, err)
 		msgReq, ok := req.(*MessagesRequest)
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "enabled", msgReq.Thinking.Type)
 		assert.Equal(t, 16000, msgReq.Thinking.BudgetTokens)
+		assert.Empty(t, msgReq.Thinking.Effort)
 		// sonnet 4 default is 16384; budget is 16000 so default already
 		// clears the constraint without adjustment
 		assert.GreaterOrEqual(t, msgReq.MaxTokens, msgReq.Thinking.BudgetTokens+1)
 	})
 
-	t.Run("medium on opus 4.7 sets budget 4000", func(t *testing.T) {
+	t.Run("medium on opus 4.5 sets budget 4000", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingMedium))
-		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+		req, err := provider.BuildRequest(messages, "claude-opus-4-5", opts, slog.Default())
 		require.NoError(t, err)
 		msgReq, ok := req.(*MessagesRequest)
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "enabled", msgReq.Thinking.Type)
 		assert.Equal(t, 4000, msgReq.Thinking.BudgetTokens)
+		assert.Empty(t, msgReq.Thinking.Effort)
 	})
 
 	t.Run("high on haiku does not emit thinking", func(t *testing.T) {
@@ -738,16 +741,203 @@ func TestBuildRequest_Thinking(t *testing.T) {
 		assert.Nil(t, msgReq.Thinking)
 	})
 
-	t.Run("off omits thinking block on a thinking-capable model", func(t *testing.T) {
+	t.Run("off omits thinking block on a 4.5 model", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingOff))
-		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+		req, err := provider.BuildRequest(messages, "claude-opus-4-5", opts, slog.Default())
 		require.NoError(t, err)
 		msgReq, ok := req.(*MessagesRequest)
 		require.True(t, ok)
 		assert.Nil(t, msgReq.Thinking)
 	})
 
-	t.Run("tight max_tokens bumped above budget", func(t *testing.T) {
+	t.Run("tight max_tokens bumped above budget on 4.5", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingHigh),
+			WithMaxTokens(2048),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, 16000, msgReq.Thinking.BudgetTokens)
+		assert.Equal(t, 16000+maxTokensDefault, msgReq.MaxTokens)
+	})
+
+	t.Run("custom thinking budget is honored on 4.5", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingMedium),
+			WithThinkingBudget(8000),
+		)
+		req, err := provider.BuildRequest(messages, "claude-opus-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, 8000, msgReq.Thinking.BudgetTokens)
+	})
+}
+
+// TestParseAnthropicVersion covers the version-suffix regex, including the
+// distinction between "-4-6" (parseable) and "-4-20250514" (date stamp).
+func TestParseAnthropicVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelID   string
+		wantMajor int
+		wantMinor int
+		wantOK    bool
+	}{
+		{name: "sonnet 4.6", modelID: "claude-sonnet-4-6", wantMajor: 4, wantMinor: 6, wantOK: true},
+		{name: "opus 4.7", modelID: "claude-opus-4-7", wantMajor: 4, wantMinor: 7, wantOK: true},
+		{name: "sonnet 4.5", modelID: "claude-sonnet-4-5", wantMajor: 4, wantMinor: 5, wantOK: true},
+		{name: "sonnet 4.6 with date suffix", modelID: "claude-sonnet-4-6-20260101", wantMajor: 4, wantMinor: 6, wantOK: true},
+		{name: "4.0-era date snapshot", modelID: "claude-sonnet-4-20250514", wantOK: false},
+		{name: "3-7-sonnet dated", modelID: "claude-3-7-sonnet-20241022", wantMajor: 3, wantMinor: 7, wantOK: true},
+		{name: "haiku 4.5", modelID: "claude-haiku-4-5", wantMajor: 4, wantMinor: 5, wantOK: true},
+		{name: "non-claude id", modelID: "gpt-5", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, ok := parseAnthropicVersion(tt.modelID)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantMajor, major)
+				assert.Equal(t, tt.wantMinor, minor)
+			}
+		})
+	}
+}
+
+// TestUseAdaptiveThinking verifies the 4.6+ routing gate.
+func TestUseAdaptiveThinking(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		want    bool
+	}{
+		{name: "sonnet 4.6", modelID: "claude-sonnet-4-6", want: true},
+		{name: "opus 4.7", modelID: "claude-opus-4-7", want: true},
+		{name: "sonnet 4.5", modelID: "claude-sonnet-4-5", want: false},
+		{name: "opus 4.0", modelID: "claude-opus-4-0", want: false},
+		{name: "3-7-sonnet", modelID: "claude-3-7-sonnet-20241022", want: false},
+		{name: "haiku 4.5", modelID: "claude-haiku-4-5", want: false},
+		{name: "date-snapshot 4.0 era", modelID: "claude-sonnet-4-20250514", want: false},
+		{name: "non-claude", modelID: "gpt-5", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, useAdaptiveThinking(tt.modelID))
+		})
+	}
+}
+
+// TestSupportsMaxEffort verifies the allowlist for the max effort tier.
+func TestSupportsMaxEffort(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		want    bool
+	}{
+		{name: "opus 4.6 max-capable", modelID: "claude-opus-4-6", want: true},
+		{name: "opus 4.7 max-capable", modelID: "claude-opus-4-7", want: true},
+		{name: "sonnet 4.6 max-capable", modelID: "claude-sonnet-4-6", want: true},
+		{name: "mythos preview max-capable", modelID: "claude-mythos-preview", want: true},
+		{name: "sonnet 4.7 hypothetical falls back", modelID: "claude-sonnet-4-7", want: false},
+		{name: "haiku 4.6 hypothetical falls back", modelID: "claude-haiku-4-6", want: false},
+		{name: "sonnet 4.5 not max", modelID: "claude-sonnet-4-5", want: false},
+		{name: "non-claude not max", modelID: "gpt-5", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, supportsMaxEffort(tt.modelID))
+		})
+	}
+}
+
+// TestEffortForLevel covers the tri-state effort mapping with and without
+// max-effort support.
+func TestEffortForLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level common.ThinkingLevel
+		maxOK bool
+		want  string
+	}{
+		{name: "off regardless of maxOK", level: common.ThinkingOff, maxOK: true, want: "low"},
+		{name: "off on non-max", level: common.ThinkingOff, maxOK: false, want: "low"},
+		{name: "medium regardless of maxOK", level: common.ThinkingMedium, maxOK: true, want: "medium"},
+		{name: "medium on non-max", level: common.ThinkingMedium, maxOK: false, want: "medium"},
+		{name: "high upgrades to max when allowed", level: common.ThinkingHigh, maxOK: true, want: "max"},
+		{name: "high falls back to high when not allowed", level: common.ThinkingHigh, maxOK: false, want: "high"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, effortForLevel(tt.level, tt.maxOK))
+		})
+	}
+}
+
+// TestBuildRequest_ThinkingAdaptive covers the 4.6+ adaptive path: the
+// thinking block carries type=adaptive plus an effort string (never a
+// budget_tokens value), and max_tokens is not bumped because adaptive
+// self-manages its reasoning budget.
+func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Explain the windmill's collapse."},
+	}
+
+	t.Run("high on sonnet 4.6 maps to max", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
+		assert.Equal(t, "max", msgReq.Thinking.Effort)
+		assert.Equal(t, 0, msgReq.Thinking.BudgetTokens)
+	})
+
+	t.Run("high on opus 4.7 maps to max", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
+		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
+		assert.Equal(t, "max", msgReq.Thinking.Effort)
+	})
+
+	t.Run("medium on sonnet 4.6 maps to medium", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingMedium))
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
+		assert.Equal(t, "medium", msgReq.Thinking.Effort)
+	})
+
+	t.Run("off on sonnet 4.6 still sends adaptive with low effort", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingOff))
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
+		assert.Equal(t, "low", msgReq.Thinking.Effort)
+	})
+
+	t.Run("adaptive does not bump max_tokens on tight setting", func(t *testing.T) {
 		opts := NewGenerateOptions(
 			WithThinking(common.ThinkingHigh),
 			WithMaxTokens(2048),
@@ -757,21 +947,20 @@ func TestBuildRequest_Thinking(t *testing.T) {
 		msgReq, ok := req.(*MessagesRequest)
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
-		assert.Equal(t, 16000, msgReq.Thinking.BudgetTokens)
-		assert.Equal(t, 16000+maxTokensDefault, msgReq.MaxTokens)
+		assert.Equal(t, 2048, msgReq.MaxTokens)
 	})
 
-	t.Run("custom thinking budget is honored", func(t *testing.T) {
-		opts := NewGenerateOptions(
-			WithThinking(common.ThinkingMedium),
-			WithThinkingBudget(8000),
-		)
-		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+	t.Run("high on adaptive-but-not-max falls back to high", func(t *testing.T) {
+		// hypothetical future sonnet past 4.6: adaptive routing kicks in
+		// (minor=7 >= 6) but the model is not in the max-effort allowlist
+		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-7", opts, slog.Default())
 		require.NoError(t, err)
 		msgReq, ok := req.(*MessagesRequest)
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
-		assert.Equal(t, 8000, msgReq.Thinking.BudgetTokens)
+		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
+		assert.Equal(t, "high", msgReq.Thinking.Effort)
 	})
 }
 

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -705,7 +705,7 @@ func TestBuildRequest_Thinking(t *testing.T) {
 		{Role: "user", Content: "Why does Boxer trust Napoleon?"},
 	}
 
-	t.Run("high on sonnet 4.5 sets budget 16000 and bumps max_tokens", func(t *testing.T) {
+	t.Run("high on sonnet 4.5 sets budget 16000 and bumps max_tokens, no effort", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
 		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
 		require.NoError(t, err)
@@ -714,13 +714,16 @@ func TestBuildRequest_Thinking(t *testing.T) {
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "enabled", msgReq.Thinking.Type)
 		assert.Equal(t, 16000, msgReq.Thinking.BudgetTokens)
-		assert.Empty(t, msgReq.Thinking.Effort)
 		// sonnet 4 default is 16384; budget is 16000 so default already
 		// clears the constraint without adjustment
 		assert.GreaterOrEqual(t, msgReq.MaxTokens, msgReq.Thinking.BudgetTokens+1)
+		// sonnet 4.5 isn't in the effort allowlist
+		if msgReq.OutputConfig != nil {
+			assert.Empty(t, msgReq.OutputConfig.Effort)
+		}
 	})
 
-	t.Run("medium on opus 4.5 sets budget 4000", func(t *testing.T) {
+	t.Run("medium on opus 4.5 sets budget 4000 and effort medium", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingMedium))
 		req, err := provider.BuildRequest(messages, "claude-opus-4-5", opts, slog.Default())
 		require.NoError(t, err)
@@ -729,7 +732,9 @@ func TestBuildRequest_Thinking(t *testing.T) {
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "enabled", msgReq.Thinking.Type)
 		assert.Equal(t, 4000, msgReq.Thinking.BudgetTokens)
-		assert.Empty(t, msgReq.Thinking.Effort)
+		// opus 4.5 is in the effort allowlist even though it uses manual thinking
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "medium", msgReq.OutputConfig.Effort)
 	})
 
 	t.Run("high on haiku does not emit thinking", func(t *testing.T) {
@@ -741,13 +746,29 @@ func TestBuildRequest_Thinking(t *testing.T) {
 		assert.Nil(t, msgReq.Thinking)
 	})
 
-	t.Run("off omits thinking block on a 4.5 model", func(t *testing.T) {
+	t.Run("off omits thinking block on opus 4.5 but still sends low effort", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingOff))
 		req, err := provider.BuildRequest(messages, "claude-opus-4-5", opts, slog.Default())
 		require.NoError(t, err)
 		msgReq, ok := req.(*MessagesRequest)
 		require.True(t, ok)
 		assert.Nil(t, msgReq.Thinking)
+		// opus 4.5 is in supportsEffort; off maps to low regardless of thinking
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "low", msgReq.OutputConfig.Effort)
+	})
+
+	t.Run("off on sonnet 4.5 emits neither thinking nor effort", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingOff))
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		assert.Nil(t, msgReq.Thinking)
+		// sonnet 4.5 isn't in supportsEffort, so no OutputConfig is created
+		if msgReq.OutputConfig != nil {
+			assert.Empty(t, msgReq.OutputConfig.Effort)
+		}
 	})
 
 	t.Run("tight max_tokens bumped above budget on 4.5", func(t *testing.T) {
@@ -892,7 +913,7 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 		{Role: "user", Content: "Explain the windmill's collapse."},
 	}
 
-	t.Run("high on sonnet 4.6 maps to max", func(t *testing.T) {
+	t.Run("high on sonnet 4.6 maps to max on output_config", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
 		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
 		require.NoError(t, err)
@@ -900,11 +921,12 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
-		assert.Equal(t, "max", msgReq.Thinking.Effort)
 		assert.Equal(t, 0, msgReq.Thinking.BudgetTokens)
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "max", msgReq.OutputConfig.Effort)
 	})
 
-	t.Run("high on opus 4.7 maps to max", func(t *testing.T) {
+	t.Run("high on opus 4.7 maps to max on output_config", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
 		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
 		require.NoError(t, err)
@@ -912,10 +934,11 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
-		assert.Equal(t, "max", msgReq.Thinking.Effort)
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "max", msgReq.OutputConfig.Effort)
 	})
 
-	t.Run("medium on sonnet 4.6 maps to medium", func(t *testing.T) {
+	t.Run("medium on sonnet 4.6 maps to medium on output_config", func(t *testing.T) {
 		opts := NewGenerateOptions(WithThinking(common.ThinkingMedium))
 		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
 		require.NoError(t, err)
@@ -923,7 +946,8 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
-		assert.Equal(t, "medium", msgReq.Thinking.Effort)
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "medium", msgReq.OutputConfig.Effort)
 	})
 
 	t.Run("off on sonnet 4.6 still sends adaptive with low effort", func(t *testing.T) {
@@ -934,7 +958,8 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
-		assert.Equal(t, "low", msgReq.Thinking.Effort)
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "low", msgReq.OutputConfig.Effort)
 	})
 
 	t.Run("adaptive does not bump max_tokens on tight setting", func(t *testing.T) {
@@ -952,7 +977,9 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 
 	t.Run("high on adaptive-but-not-max falls back to high", func(t *testing.T) {
 		// hypothetical future sonnet past 4.6: adaptive routing kicks in
-		// (minor=7 >= 6) but the model is not in the max-effort allowlist
+		// (minor=7 >= 6) but the model is not in the max-effort allowlist.
+		// this also exercises the adaptive-thinking-without-effort branch
+		// since sonnet-4-7 isn't in supportsEffort either
 		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
 		req, err := provider.BuildRequest(messages, "claude-sonnet-4-7", opts, slog.Default())
 		require.NoError(t, err)
@@ -960,7 +987,10 @@ func TestBuildRequest_ThinkingAdaptive(t *testing.T) {
 		require.True(t, ok)
 		require.NotNil(t, msgReq.Thinking)
 		assert.Equal(t, "adaptive", msgReq.Thinking.Type)
-		assert.Equal(t, "high", msgReq.Thinking.Effort)
+		// sonnet-4-7 isn't yet in supportsEffort, so no effort is sent
+		if msgReq.OutputConfig != nil {
+			assert.Empty(t, msgReq.OutputConfig.Effort)
+		}
 	})
 }
 
@@ -1134,4 +1164,104 @@ func TestBuildOptions_ThinkingAndSchema(t *testing.T) {
 	assert.JSONEq(t, schema, string(ga.ResponseFormat.Schema))
 	require.NotNil(t, ga.ResponseFormat.Strict)
 	assert.True(t, *ga.ResponseFormat.Strict)
+}
+
+// TestSupportsEffort covers the allowlist for the output_config.effort
+// parameter. note that opus 4.5 supports effort even though it uses the
+// manual (enabled+budget_tokens) thinking shape.
+func TestSupportsEffort(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		want    bool
+	}{
+		{name: "opus 4.5 supports effort", modelID: "claude-opus-4-5", want: true},
+		{name: "opus 4.6 supports effort", modelID: "claude-opus-4-6", want: true},
+		{name: "opus 4.7 supports effort", modelID: "claude-opus-4-7", want: true},
+		{name: "sonnet 4.6 supports effort", modelID: "claude-sonnet-4-6", want: true},
+		{name: "mythos preview supports effort", modelID: "claude-mythos-preview", want: true},
+		{name: "sonnet 4.5 does not support effort", modelID: "claude-sonnet-4-5", want: false},
+		{name: "haiku 4.5 does not support effort", modelID: "claude-haiku-4-5", want: false},
+		{name: "3-7-sonnet does not support effort", modelID: "claude-3-7-sonnet-20241022", want: false},
+		{name: "non-claude does not support effort", modelID: "gpt-5", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, supportsEffort(tt.modelID))
+		})
+	}
+}
+
+// TestBuildRequest_EffortOnOpus45 confirms that opus 4.5 gets both manual
+// thinking (enabled+budget_tokens) and output_config.effort together —
+// effort is independent of the adaptive-thinking routing.
+func TestBuildRequest_EffortOnOpus45(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Describe Snowball's role on the farm."},
+	}
+
+	t.Run("medium emits manual thinking plus medium effort", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingMedium))
+		req, err := provider.BuildRequest(messages, "claude-opus-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "enabled", msgReq.Thinking.Type)
+		assert.Equal(t, 4000, msgReq.Thinking.BudgetTokens)
+
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "medium", msgReq.OutputConfig.Effort)
+		// no schema requested, so format stays nil
+		assert.Nil(t, msgReq.OutputConfig.Format)
+	})
+
+	t.Run("high on opus 4.5 falls back to high effort (max is 4.6+)", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
+		req, err := provider.BuildRequest(messages, "claude-opus-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "enabled", msgReq.Thinking.Type)
+		assert.Equal(t, 16000, msgReq.Thinking.BudgetTokens)
+
+		require.NotNil(t, msgReq.OutputConfig)
+		assert.Equal(t, "high", msgReq.OutputConfig.Effort)
+	})
+}
+
+// TestBuildRequest_EffortAndSchemaCoexist confirms that a request with
+// both a schema (WithSchema) and a thinking level populates both fields
+// of output_config: format for the schema, effort for the thinking lever.
+func TestBuildRequest_EffortAndSchemaCoexist(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Return the windmill quote."},
+	}
+	schema := []byte(`{"type":"object","properties":{"quote":{"type":"string"}}}`)
+
+	opts := NewGenerateOptions(
+		WithThinking(common.ThinkingHigh),
+		WithSchema("animal_quote", schema),
+	)
+	req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+	require.NoError(t, err)
+	msgReq, ok := req.(*MessagesRequest)
+	require.True(t, ok)
+
+	require.NotNil(t, msgReq.Thinking)
+	assert.Equal(t, "adaptive", msgReq.Thinking.Type)
+
+	require.NotNil(t, msgReq.OutputConfig)
+	// both output_config fields are populated together
+	assert.Equal(t, "max", msgReq.OutputConfig.Effort)
+	require.NotNil(t, msgReq.OutputConfig.Format)
+	assert.Equal(t, "json_schema", msgReq.OutputConfig.Format.Type)
+	assert.Equal(t, "animal_quote", msgReq.OutputConfig.Format.Name)
+	assert.JSONEq(t, string(schema), string(msgReq.OutputConfig.Format.Schema))
 }

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -174,7 +174,7 @@ func TestProvider_BuildRequest(t *testing.T) {
 				Model:     modelName,
 				Messages:  []common.Message{{Role: "user", Content: "Can you not understand that liberty is worth more than just ribbons?"}},
 				System:    "You are a helpful assistant.",
-				MaxTokens: 1024,
+				MaxTokens: maxTokensDefault,
 				Stream:    common.BoolPtr(false),
 			},
 		},
@@ -204,7 +204,7 @@ func TestProvider_BuildRequest(t *testing.T) {
 				Model:     modelName,
 				Messages:  []common.Message{{Role: "user", Content: "Can you not understand that liberty is worth more than just ribbons?"}},
 				System:    "You are a helpful assistant.",
-				MaxTokens: 1024,
+				MaxTokens: maxTokensDefault,
 				Stream:    common.BoolPtr(false),
 			},
 		},
@@ -641,4 +641,308 @@ func TestProvider_Integration(t *testing.T) {
 	content, err := client.Generate(context.Background(), messages, "claude-3-5-sonnet-latest")
 	require.NoError(t, err)
 	assert.Equal(t, "test response", content)
+}
+
+// TestSupportsThinking verifies the model id allowlist that drives
+// whether BuildRequest emits Anthropic's extended-thinking block.
+func TestSupportsThinking(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		want    bool
+	}{
+		{name: "sonnet 4.6 supports", modelID: "claude-sonnet-4-6", want: true},
+		{name: "sonnet 4 latest supports", modelID: "claude-sonnet-4-latest", want: true},
+		{name: "opus 4.7 supports", modelID: "claude-opus-4-7", want: true},
+		{name: "opus 4.0 supports", modelID: "claude-opus-4-0", want: true},
+		{name: "3-7 sonnet supports", modelID: "claude-3-7-sonnet-latest", want: true},
+		{name: "haiku 3 does not", modelID: "claude-3-haiku-20240307", want: false},
+		{name: "haiku 4.5 does not", modelID: "claude-haiku-4-5", want: false},
+		{name: "3-5 sonnet does not", modelID: "claude-3-5-sonnet-latest", want: false},
+		{name: "empty does not", modelID: "", want: false},
+		{name: "unknown does not", modelID: "snowball-1.0", want: false},
+		{name: "uppercase opus still supports", modelID: "CLAUDE-OPUS-4-7", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, supportsThinking(tt.modelID))
+		})
+	}
+}
+
+// TestDefaultMaxTokens covers the per-model fallback used when the caller
+// hasn't set MaxTokens. Sonnet 4 and Opus 4 families get larger budgets so
+// the windmill has room to stand; everything else gets the modest default.
+func TestDefaultMaxTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		want    int
+	}{
+		{name: "sonnet 4.6", modelID: "claude-sonnet-4-6", want: maxTokensSonnetFamily4},
+		{name: "sonnet 4.0", modelID: "claude-sonnet-4-0", want: maxTokensSonnetFamily4},
+		{name: "opus 4.7", modelID: "claude-opus-4-7", want: maxTokensOpusFamily4},
+		{name: "opus 4.5", modelID: "claude-opus-4-5", want: maxTokensOpusFamily4},
+		{name: "haiku 4.5", modelID: "claude-haiku-4-5", want: maxTokensDefault},
+		{name: "3-5 sonnet", modelID: "claude-3-5-sonnet-latest", want: maxTokensDefault},
+		{name: "unknown", modelID: "napoleon-1", want: maxTokensDefault},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, defaultMaxTokens(tt.modelID))
+		})
+	}
+}
+
+// TestBuildRequest_Thinking covers the cross-provider ThinkingLevel →
+// Anthropic thinking-block translation, including the model id gate and
+// the max_tokens/budget_tokens constraint.
+func TestBuildRequest_Thinking(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Why does Boxer trust Napoleon?"},
+	}
+
+	t.Run("high on sonnet 4.6 sets budget 16000 and bumps max_tokens", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, "enabled", msgReq.Thinking.Type)
+		assert.Equal(t, 16000, msgReq.Thinking.BudgetTokens)
+		// sonnet 4 default is 16384; budget is 16000 so default already
+		// clears the constraint without adjustment
+		assert.GreaterOrEqual(t, msgReq.MaxTokens, msgReq.Thinking.BudgetTokens+1)
+	})
+
+	t.Run("medium on opus 4.7 sets budget 4000", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingMedium))
+		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, 4000, msgReq.Thinking.BudgetTokens)
+	})
+
+	t.Run("high on haiku does not emit thinking", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingHigh))
+		req, err := provider.BuildRequest(messages, "claude-haiku-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		assert.Nil(t, msgReq.Thinking)
+	})
+
+	t.Run("off omits thinking block on a thinking-capable model", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingOff))
+		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		assert.Nil(t, msgReq.Thinking)
+	})
+
+	t.Run("tight max_tokens bumped above budget", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingHigh),
+			WithMaxTokens(2048),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, 16000, msgReq.Thinking.BudgetTokens)
+		assert.Equal(t, 16000+maxTokensDefault, msgReq.MaxTokens)
+	})
+
+	t.Run("custom thinking budget is honored", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingMedium),
+			WithThinkingBudget(8000),
+		)
+		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Equal(t, 8000, msgReq.Thinking.BudgetTokens)
+	})
+}
+
+// TestBuildRequest_OutputConfig verifies that WithSchema wires the schema
+// onto Anthropic's output_config envelope with strict mode preserved.
+func TestBuildRequest_OutputConfig(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Return the quote"},
+	}
+	schema := []byte(`{"type":"object","properties":{"quote":{"type":"string"}}}`)
+
+	opts := NewGenerateOptions(WithSchema("animal_quote", schema))
+	req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+	require.NoError(t, err)
+
+	msgReq, ok := req.(*MessagesRequest)
+	require.True(t, ok)
+	require.NotNil(t, msgReq.OutputConfig)
+	require.NotNil(t, msgReq.OutputConfig.Format)
+
+	fmt := msgReq.OutputConfig.Format
+	assert.Equal(t, "json_schema", fmt.Type)
+	assert.Equal(t, "animal_quote", fmt.Name)
+	assert.JSONEq(t, string(schema), string(fmt.Schema))
+	require.NotNil(t, fmt.Strict)
+	assert.True(t, *fmt.Strict)
+}
+
+// TestBuildRequest_PerModelMaxTokens covers the per-model defaults picked
+// when the caller hasn't set MaxTokens.
+func TestBuildRequest_PerModelMaxTokens(t *testing.T) {
+	provider := New()
+	messages := []common.Message{{Role: "user", Content: "hello"}}
+
+	tests := []struct {
+		name    string
+		modelID string
+		want    int
+	}{
+		{name: "sonnet 4.6 default", modelID: "claude-sonnet-4-6", want: maxTokensSonnetFamily4},
+		{name: "opus 4.7 default", modelID: "claude-opus-4-7", want: maxTokensOpusFamily4},
+		{name: "haiku default", modelID: "claude-haiku-4-5", want: maxTokensDefault},
+		{name: "legacy sonnet default", modelID: "claude-3-5-sonnet-latest", want: maxTokensDefault},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := provider.BuildRequest(messages, tt.modelID, nil, slog.Default())
+			require.NoError(t, err)
+			msgReq, ok := req.(*MessagesRequest)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, msgReq.MaxTokens)
+		})
+	}
+
+	t.Run("caller MaxTokens wins", func(t *testing.T) {
+		opts := NewGenerateOptions(WithMaxTokens(1234))
+		req, err := provider.BuildRequest(messages, "claude-opus-4-7", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		assert.Equal(t, 1234, msgReq.MaxTokens)
+	})
+}
+
+// TestParseResponse_ThinkingBlocks covers Anthropic's content-block thinking
+// being re-inlined as a <think> prefix so the downstream filter treats it
+// the same as any other provider's inline-tag thinking.
+func TestParseResponse_ThinkingBlocks(t *testing.T) {
+	provider := New()
+
+	body := `{
+		"id": "msg_abc",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "thinking", "thinking": "Snowball drew the plans for the windmill."},
+			{"type": "text", "text": "Four legs good, two legs bad."}
+		],
+		"model": "claude-opus-4-7",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 12, "output_tokens": 7}
+	}`
+
+	content, usage, err := provider.ParseResponse([]byte(body), slog.Default())
+	require.NoError(t, err)
+	assert.Equal(t,
+		"<think>Snowball drew the plans for the windmill.</think>\nFour legs good, two legs bad.",
+		content,
+	)
+	require.NotNil(t, usage)
+	assert.Equal(t, 12, usage.PromptTokens)
+	assert.Equal(t, 7, usage.CompletionTokens)
+	assert.Equal(t, 19, usage.TotalTokens)
+}
+
+// TestParseResponse_MultipleThinkingBlocks confirms that multiple thinking
+// blocks are concatenated before being wrapped in a single <think> tag.
+func TestParseResponse_MultipleThinkingBlocks(t *testing.T) {
+	provider := New()
+
+	body := `{
+		"id": "msg_abc",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "thinking", "thinking": "First, consider the cowshed."},
+			{"type": "thinking", "thinking": " Then the windmill."},
+			{"type": "text", "text": "Boxer will work harder."}
+		],
+		"model": "claude-opus-4-7",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 1, "output_tokens": 1}
+	}`
+
+	content, _, err := provider.ParseResponse([]byte(body), slog.Default())
+	require.NoError(t, err)
+	assert.Equal(t,
+		"<think>First, consider the cowshed. Then the windmill.</think>\nBoxer will work harder.",
+		content,
+	)
+}
+
+// TestParseResponse_NoThinking confirms that plain text responses pass
+// through untouched when no thinking blocks are present.
+func TestParseResponse_NoThinking(t *testing.T) {
+	provider := New()
+
+	body := `{
+		"id": "msg_abc",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{"type": "text", "text": "All animals are equal."}
+		],
+		"model": "claude-opus-4-7",
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 3, "output_tokens": 5}
+	}`
+
+	content, _, err := provider.ParseResponse([]byte(body), slog.Default())
+	require.NoError(t, err)
+	assert.Equal(t, "All animals are equal.", content)
+}
+
+// TestBuildOptions_ThinkingAndSchema verifies BuildOptions reads the
+// thinking level and response schema out of config.Parameters and wires
+// them onto the returned GenerateOptions.
+func TestBuildOptions_ThinkingAndSchema(t *testing.T) {
+	provider := New()
+	schema := `{"type":"object","properties":{"a":{"type":"integer"}}}`
+
+	cfg := &config.Config{
+		Parameters: config.Parameters{
+			Thinking:       "high",
+			ResponseSchema: schema,
+		},
+		Format: config.Format{},
+	}
+
+	opts := provider.BuildOptions(cfg)
+	require.Len(t, opts, 1)
+	ga, ok := opts[0].(*GenerateOptions)
+	require.True(t, ok)
+
+	assert.Equal(t, common.ThinkingHigh, ga.Thinking)
+	require.NotNil(t, ga.ResponseFormat)
+	assert.Equal(t, "json_schema", ga.ResponseFormat.Type)
+	assert.Equal(t, "response", ga.ResponseFormat.Name)
+	assert.JSONEq(t, schema, string(ga.ResponseFormat.Schema))
+	require.NotNil(t, ga.ResponseFormat.Strict)
+	assert.True(t, *ga.ResponseFormat.Strict)
 }

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -1345,4 +1345,49 @@ func TestBuildRequest_TemperatureForcedWhenThinking(t *testing.T) {
 		require.NotNil(t, msgReq.Temperature)
 		assert.Equal(t, 0.4, *msgReq.Temperature)
 	})
+
+	t.Run("adaptive thinking drops top_p to satisfy temp/top_p exclusion", func(t *testing.T) {
+		// Anthropic rejects requests that set both temperature and top_p,
+		// and we force temperature=1 for thinking, so top_p must be dropped
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingHigh),
+			WithTemperature(0.7),
+			WithTopP(0.95),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		require.NotNil(t, msgReq.Temperature)
+		assert.Equal(t, 1.0, *msgReq.Temperature)
+		assert.Nil(t, msgReq.TopP)
+	})
+
+	t.Run("enabled thinking on 4.5 also drops top_p", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingMedium),
+			WithTopP(0.9),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		assert.Nil(t, msgReq.TopP)
+	})
+
+	t.Run("no thinking preserves top_p", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingOff),
+			WithTopP(0.85),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		assert.Nil(t, msgReq.Thinking)
+		require.NotNil(t, msgReq.TopP)
+		assert.Equal(t, 0.85, *msgReq.TopP)
+	})
 }

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -1265,3 +1265,84 @@ func TestBuildRequest_EffortAndSchemaCoexist(t *testing.T) {
 	assert.Equal(t, "animal_quote", msgReq.OutputConfig.Format.Name)
 	assert.JSONEq(t, string(schema), string(msgReq.OutputConfig.Format.Schema))
 }
+
+// TestBuildRequest_TemperatureForcedWhenThinking confirms Anthropic's
+// requirement that temperature=1 whenever the thinking block is present,
+// regardless of what temperature the caller set. Also confirms that
+// temperature passes through unchanged when thinking is not active.
+func TestBuildRequest_TemperatureForcedWhenThinking(t *testing.T) {
+	provider := New()
+	messages := []common.Message{
+		{Role: "user", Content: "Consider the windmill's collapse."},
+	}
+
+	t.Run("adaptive on sonnet 4.6 forces temperature 1 over caller's 0.7", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingHigh),
+			WithTemperature(0.7),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		require.NotNil(t, msgReq.Temperature)
+		assert.Equal(t, 1.0, *msgReq.Temperature)
+	})
+
+	t.Run("enabled on sonnet 4.5 forces temperature 1", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingMedium),
+			WithTemperature(0.2),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		require.NotNil(t, msgReq.Temperature)
+		assert.Equal(t, 1.0, *msgReq.Temperature)
+	})
+
+	t.Run("adaptive on sonnet 4.6 with no caller temp still sets 1", func(t *testing.T) {
+		opts := NewGenerateOptions(WithThinking(common.ThinkingMedium))
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-6", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		require.NotNil(t, msgReq.Thinking)
+		require.NotNil(t, msgReq.Temperature)
+		assert.Equal(t, 1.0, *msgReq.Temperature)
+	})
+
+	t.Run("off on sonnet 4.5 preserves caller temperature", func(t *testing.T) {
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingOff),
+			WithTemperature(0.3),
+		)
+		req, err := provider.BuildRequest(messages, "claude-sonnet-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		// sonnet 4.5 + off sends no thinking block, so caller's temperature wins
+		assert.Nil(t, msgReq.Thinking)
+		require.NotNil(t, msgReq.Temperature)
+		assert.Equal(t, 0.3, *msgReq.Temperature)
+	})
+
+	t.Run("haiku with thinking-high never gets a thinking block or forced temp", func(t *testing.T) {
+		// haiku is outside supportsThinking so the thinking block is never
+		// set; caller's temperature passes through untouched
+		opts := NewGenerateOptions(
+			WithThinking(common.ThinkingHigh),
+			WithTemperature(0.4),
+		)
+		req, err := provider.BuildRequest(messages, "claude-haiku-4-5", opts, slog.Default())
+		require.NoError(t, err)
+		msgReq, ok := req.(*MessagesRequest)
+		require.True(t, ok)
+		assert.Nil(t, msgReq.Thinking)
+		require.NotNil(t, msgReq.Temperature)
+		assert.Equal(t, 0.4, *msgReq.Temperature)
+	})
+}


### PR DESCRIPTION


- Adds support for thinking/effort, adds compatibility for 4.6+ models without breaking legacy models.
- Also shifts version number to 0.2 given the recent scaffolding related to thinking budget and output schema